### PR TITLE
ARXIVNG-875 add form field and validation for policy acknowledgement

### DIFF
--- a/submit/controllers/authorship.py
+++ b/submit/controllers/authorship.py
@@ -56,7 +56,7 @@ class AuthorshipForm(Form):
     NO = 'n'
 
     authorship = RadioField(choices=[(YES, 'I am an author of this paper'),
-                            (NO, 'I am not an author of this paper')],
+                                     (NO, 'I am not an author of this paper')],
                             validators=[InputRequired('Please choose one')])
     proxy = BooleanField('By checking this box, I certify that I have '
                          'received authorization from arXiv to submit papers '

--- a/submit/controllers/policy.py
+++ b/submit/controllers/policy.py
@@ -7,14 +7,15 @@ Creates an event of type `core.events.event.AcceptPolicy`
 from typing import Tuple, Dict, Any
 
 from flask import url_for
-from wtforms import Form
+from wtforms import Form, BooleanField
+from wtforms.validators import InputRequired
 
 from arxiv import status
 from arxiv.base import logging
 import events
 from .util import flow_control
 
-# from arxiv-submission-core.events.event import VerifyContactInformation
+# from arxiv-submission-core.events.event import AcceptPolicy
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
@@ -30,14 +31,27 @@ def policy(request_params: dict, submission_id: int) -> Response:
     # Process event if go to next page
     action = request_params.get('action')
     if action in ['previous', 'save_exit', 'next'] and form.validate():
-        # TODO: Write submission info
+        # TODO: Create a concrete User event from cookie info.
+        submitter = events.domain.User(1, email='ian413@cornell.edu',
+                                       forename='Ima', surname='Nauthor')
+
+        # Create AcceptPolicy event
+        submission, stack = events.save(  # pylint: disable=W0612
+            events.AcceptPolicy(creator=submitter),
+            submission_id=submission_id
+        )
         return response_data, status.HTTP_303_SEE_OTHER, {}
 
     # build response form
     response_data.update({'form': form})
-    logger.debug(f'verify_user data: {form}')
+    logger.debug(f'policy data: {form}')
     return response_data, status.HTTP_200_OK, {}
 
 
 class PolicyForm(Form):
     """Generate form with checkbox to confirm policy."""
+
+    policy = BooleanField(
+        'By checking this box, I agree to the policies listed on this page.',
+        [InputRequired('Please check the box to agree to the policies')]
+    )

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -64,14 +64,20 @@ def license(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/policy', methods=['GET'])
-def policy_ack(submission_id):
+def policy(submission_id):
     """Render step 4, policy agreement."""
-    rendered = render_template(
-        "submit/policy.html",
-        pagetitle='Acknowledge Policy Statement'
-    )
-    response = make_response(rendered, status.HTTP_200_OK)
-    return response
+    response, code, headers = controllers.policy(request.args, submission_id)
+
+    if code == status.HTTP_200_OK:
+        rendered = render_template(
+            "submit/policy.html",
+            pagetitle='Acknowledge Policy Statement',
+            **response
+        )
+        response = make_response(rendered, status.HTTP_200_OK)
+        return response
+    elif code == status.HTTP_303_SEE_OTHER:
+        return redirect(headers['Location'], code=code)
 
 
 @blueprint.route('/<int:submission_id>/classification', methods=['GET'])

--- a/submit/templates/submit/policy.html
+++ b/submit/templates/submit/policy.html
@@ -14,16 +14,19 @@
   <li>For third-party submissions, I have obtained pre-authorization from arXiv
     to submit as a third-party submitter.</li>
 </ul>
-
+<form method="GET" action="{{ url_for('ui.policy',submission_id=submission_id) }}">
 <div class="field">
   <div class="control">
-    <label class="checkbox">
-      <input type="checkbox" id="policy_ack" name="policy_ack" value="y">
-      By checking this box, I agree to the above policies.
-    </label>
+    <div class="checkbox">
+      {{ form.policy }}
+      {{ form.policy.label }}
+    </div>
+    {% for error in form.policy.errors %}
+      <p class="help is-warning">{{ error }}</p>
+    {% endfor %}
   </div>
 </div>
 
 {{ submit_macros.submit_nav() }}
-
+</form>
 {% endblock within_content %}


### PR DESCRIPTION
This PR creates the form field for policy acknowledgement and adds a simple yes/no verification on the field, raising an error in the event that the box is not checked.  Pretty sure this is in line with the state of where the previous pages are.  Some of this was done a bit blindly -- followed the pattern for event creation from authorship and verify_user.

Note: I noticed that the handy progress bar links aren't going to work any more due to not having submission_id passed and also we don't want to have the skip forward...took a short stab at how that might work but ended up aborting the effort for now. It's a separate task from this PR and possibly out of scope for the sprint.