### PR TITLE
ARXIVNG-897 added InvalidStack handling to verify_user controller, and tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,6 @@
 omit =
     app.py
     docs/*
-    test*
+    */test*
     */app.py
     */wsgi.py

--- a/Pipfile
+++ b/Pipfile
@@ -1,18 +1,19 @@
 [[source]]
+
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
 
 [packages]
+
 arxiv-base = "==0.7.1"
-arxiv-submission-events = "*"
+arxiv-submission-events = "==0.2"
 dataclasses = "*"
 flask = "*"
 jsonschema = "*"
 uwsgi = "*"
-WTForms = "==2.1"
-# TODO: remove [pyyaml, pytz] after fixing ARXIVNG-882
+wtforms = "==2.1"
 pyyaml = "*"
 pytz = "*"
 dev = "*"
@@ -20,6 +21,7 @@ sqlalchemy = "*"
 
 
 [dev-packages]
+
 "nose2" = "*"
 pylint = "*"
 pydocstyle = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4b49ff4fd80e5988c72a1be8b4cc1779ba16e74f97ef474e58c2cbf1fe280e38"
+            "sha256": "2b15f1f94966911332619b0233759342d46f621c36625e7f3aecdf1324f2c37a"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -35,9 +35,9 @@
         },
         "arxiv-submission-events": {
             "hashes": [
-                "sha256:8794fd9dd26a96b9021ceffae199dc0401127906760e23ccb4d285f128b0c723"
+                "sha256:d9111e0fad661adaa634bee5ce885223f36d3e87d9ec2a9f23f9f9575af5f26e"
             ],
-            "version": "==0.1"
+            "version": "==0.2"
         },
         "click": {
             "hashes": [
@@ -51,14 +51,12 @@
                 "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f",
                 "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"
             ],
-            "index": "pypi",
             "version": "==0.6"
         },
         "dev": {
             "hashes": [
                 "sha256:3f84372244076c68a73fdb30359ab8ca0c826a6d04fa589e7c44a02c637a3a4c"
             ],
-            "index": "pypi",
             "version": "==0.4.0"
         },
         "flask": {
@@ -86,7 +84,6 @@
                 "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
                 "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
             ],
-            "index": "pypi",
             "version": "==2.6.0"
         },
         "markupsafe": {
@@ -125,7 +122,6 @@
             "hashes": [
                 "sha256:2d5f08f714a886a1382c18be501e614bce50d362384dc089474019ce0768151c"
             ],
-            "index": "pypi",
             "version": "==1.2.8"
         },
         "uwsgi": {
@@ -145,17 +141,16 @@
             "hashes": [
                 "sha256:ffdf10bd1fa565b8233380cb77a304cd36fd55c73023e91d4b803c96bc11d46f"
             ],
-            "index": "pypi",
             "version": "==2.1"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:032f6e09161e96f417ea7fad46d3fac7a9019c775f202182c22df0e4f714cb1c",
-                "sha256:dea42ae6e0b789b543f728ddae7ddb6740ba33a49fb52c4a4d9cb7bb4aa6ec09"
+                "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
+                "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
             ],
-            "version": "==1.6.4"
+            "version": "==1.6.5"
         },
         "certifi": {
             "hashes": [
@@ -227,10 +222,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "isort": {
             "hashes": [
@@ -290,10 +285,10 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:01cf289838f266ae7c6550c813181ee77d21eac9459dbf067e7a95a0a2db9721",
-                "sha256:bc251cb31bc236d9fe4bcc442c994c45fff2541f7161ee52dc949741fe9ca3dd"
+                "sha256:1b899802a89b67bb68f30d788bba49b61b1f28779436f06b75c03495f9d6ea5c",
+                "sha256:f472645347430282d62d1f97d12ccb8741f19f1572b7cf30b58280e4e0818739"
             ],
-            "version": "==0.600"
+            "version": "==0.610"
         },
         "nose2": {
             "hashes": [
@@ -311,17 +306,17 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:aa519865f8890a5905fa34924fed0f3bfc7d84fc9f9142c16dac52ffecd25a39",
-                "sha256:c353d8225195b37cc3aef18248b8f3fe94c5a6a95affaf885ae21a24ca31d8eb"
+                "sha256:a48070545c12430cfc4e865bf62f5ad367784765681b3db442d8230f0960aa3c",
+                "sha256:fff220bcb996b4f7e2b0f6812fd81507b72ca4d8c4d05daf2655c333800cb9b3"
             ],
-            "version": "==1.9.1"
+            "version": "==1.9.2"
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "version": "==2.18.4"
+            "version": "==2.19.1"
         },
         "six": {
             "hashes": [
@@ -362,10 +357,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
             ],
-            "version": "==1.22"
+            "version": "==1.23"
         },
         "wrapt": {
             "hashes": [

--- a/submit/controllers/authorship.py
+++ b/submit/controllers/authorship.py
@@ -4,17 +4,20 @@ Controller for authorship action.
 Creates an event of type `core.events.event.AssertAuthorship`
 """
 
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict, Any, Optional
+
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError, NotFound
 
 from flask import url_for
 from wtforms import Form, BooleanField, RadioField
-from wtforms.validators import InputRequired, ValidationError
+from wtforms.validators import InputRequired, ValidationError, optional
 
 from arxiv import status
 from arxiv.base import logging
 import events
 
-from .util import flow_control
+from .util import flow_control, load_submission
 
 # from arxiv-submission-core.events.event import VerifyContactInformation
 
@@ -23,29 +26,72 @@ logger = logging.getLogger(__name__)  # pylint: disable=C0103
 Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
 
 
-@flow_control('ui.verify_user', 'ui.license', 'ui.user')
-def authorship(request_params: dict, submission_id: int) -> Response:
-    """Convert authorship form data into an `AssertAuthorship` event."""
-    form = AuthorshipForm(request_params)
-    response_data = {'submission_id': submission_id}
-
-    # Process event if go to next page
-    action = request_params.get('action')
-    if action in ['previous', 'save_exit', 'next'] and form.validate():
-        # TODO: Create a concrete User event from cookie info.
-        submitter = events.domain.User(1, email='ian413@cornell.edu',
-                                       forename='Ima', surname='Nauthor')
-
-        # Create AssertAuthorship event
-        submission, stack = events.save(  # pylint: disable=W0612
-            events.AssertAuthorship(creator=submitter),
-            submission_id=submission_id
+def _data_from_submission(params: MultiDict,
+                          submission: events.domain.Submission) -> MultiDict:
+    """Update form data based on the current state of the submission."""
+    if submission.submitter_is_author is not None:
+        params['authorship'] = (
+            AuthorshipForm.YES if submission.submitter_is_author
+            else AuthorshipForm.NO
         )
-        return response_data, status.HTTP_303_SEE_OTHER, {}
+        # TODO: we should look at how we represent this on
+        # events.domain.Submission.
+        if submission.submitter_is_author is False:
+            params['proxy'] = True
+    return params
 
-    # build response form
-    response_data.update({'form': form})
-    logger.debug(f'verify_user data: {form}')
+
+@flow_control('ui.verify_user', 'ui.license', 'ui.user')
+def authorship(method: str, params: dict, submission_id: int,
+               user: Optional[events.domain.User] = None,
+               client: Optional[events.domain.Client] = None) -> Response:
+    """Convert authorship form data into an `AssertAuthorship` event."""
+    logger.debug(f'method: {method}, submission: {submission_id}. {params}')
+
+    # TODO: Create a concrete User from cookie info.
+    user = events.domain.User(1, email='ian413@cornell.edu',
+                              forename='Ima', surname='Nauthor')
+
+    # Will raise NotFound if there is no such submission.
+    submission = load_submission(submission_id)
+
+    # The form should be prepopulated based on the current state of the
+    # submission.
+    if method == 'GET':
+        params = _data_from_submission(params, submission)
+
+    form = AuthorshipForm(params)
+    response_data = {'submission_id': submission_id, 'form': form}
+
+    if method == 'POST':
+        if form.validate():
+            logger.debug('Form is valid, with data: %s', str(form.data))
+            value = (form.authorship.data == form.YES)
+
+            # No need to do this more than once.
+            if submission.submitter_is_author != value:
+                try:
+                    # Create AssertAuthorship event
+                    submission, stack = events.save(  # pylint: disable=W0612
+                        events.AssertAuthorship(
+                            creator=user,
+                            client=client,
+                            submitter_is_author=value
+                        ),
+                        submission_id=submission_id
+                    )
+                except events.exceptions.InvalidStack as e:
+                    logger.error('Could not AssertAuthorship: %s', str(e))
+                    form.errors     # Causes the form to initialize errors.
+                    form._errors['events'] = [ie.message for ie
+                                              in e.event_exceptions]
+                    return response_data, status.HTTP_400_BAD_REQUEST, {}
+
+            if params.get('action') in ['previous', 'save_exit', 'next']:
+                return response_data, status.HTTP_303_SEE_OTHER, {}
+        else:   # Form data were invalid.
+            return response_data, status.HTTP_400_BAD_REQUEST, {}
+
     return response_data, status.HTTP_200_OK, {}
 
 
@@ -60,7 +106,8 @@ class AuthorshipForm(Form):
                             validators=[InputRequired('Please choose one')])
     proxy = BooleanField('By checking this box, I certify that I have '
                          'received authorization from arXiv to submit papers '
-                         'on behalf of the author(s).')
+                         'on behalf of the author(s).',
+                         validators=[optional()])
 
     def validate_authorship(self, field):
         """Require proxy field if submitter is not author."""

--- a/submit/controllers/license.py
+++ b/submit/controllers/license.py
@@ -6,6 +6,7 @@ Creates an event of type `core.events.event.SelectLicense`
 
 from typing import Tuple, Dict, Any
 
+from werkzeug import MultiDict
 from flask import url_for
 from wtforms import Form
 from wtforms.fields import RadioField
@@ -15,7 +16,7 @@ from arxiv import status
 from arxiv.base import logging
 from arxiv.license import LICENSES
 import events
-from .util import flow_control
+from .util import flow_control, load_submission
 
 # from arxiv-submission-core.events.event import VerifyContactInformation
 
@@ -24,40 +25,70 @@ logger = logging.getLogger(__name__)  # pylint: disable=C0103
 Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
 
 
+def _data_from_submission(params: MultiDict,
+                          submission: events.domain.Submission) -> MultiDict:
+    """Update form data based on the current state of the submission."""
+    if submission.license:
+        params['license'] = submission.license.uri
+    return params
+
+
 @flow_control('ui.authorship', 'ui.policy', 'ui.user')
-def license(request_params: dict, submission_id: int) -> Response:
+def license(method: str, params: MultiDict, submission_id: int) -> Response:
     """Convert license form data into a `SelectLicense` event."""
-    form = LicenseForm(request_params)
-    response_data = {'submission_id': submission_id}
+    logger.debug(f'method: {method}, submission: {submission_id}. {params}')
 
-    # Process event if go to next page
-    action = request_params.get('action')
-    if action in ['previous', 'save_exit', 'next'] and form.validate():
-        # TODO: Create a concrete User event from cookie info.
-        submitter = events.domain.User(1, email='ian413@cornell.edu',
-                                       forename='Ima', surname='Nauthor')
+    # TODO: Create a concrete User from cookie info.
+    submitter = events.domain.User(1, email='ian413@cornell.edu',
+                                   forename='Ima', surname='Nauthor')
 
-        # Create SelectLicense event
-        submission, stack = events.save(  # pylint: disable=W0612
-            events.SelectLicense(
-                creator=submitter,
-                license_uri=form.license.data
-            ),
-            submission_id=submission_id
-        )
-        return response_data, status.HTTP_303_SEE_OTHER, {}
+    # Will raise NotFound if there is no such submission.
+    submission = load_submission(submission_id)
 
-    # build response form
-    response_data.update({'form': form})
-    logger.debug(f'verify_user data: {form}')
+    # The form should be prepopulated based on the current state of the
+    # submission.
+    if method == 'GET':
+        params = _data_from_submission(params, submission)
+
+    form = LicenseForm(params)
+    response_data = {'submission_id': submission_id, 'form': form}
+
+    if method == 'POST':
+        if form.validate():
+            logger.debug('Form is valid, with data: %s', str(form.data))
+            license_uri = form.license.data
+
+            # If already selected, nothing more to do.
+            if not submission.license or submission.license.uri != license_uri:
+                try:
+                    # Create SelectLicense event
+                    submission, stack = events.save(  # pylint: disable=W0612
+                        events.SelectLicense(creator=submitter,
+                                             license_uri=license_uri),
+                        submission_id=submission_id
+                    )
+                except events.exceptions.InvalidStack as e:
+                    logger.error('Could not AssertAuthorship: %s', str(e))
+                    form.errors     # Causes the form to initialize errors.
+                    form._errors['events'] = [ie.message for ie
+                                              in e.event_exceptions]
+                    return response_data, status.HTTP_400_BAD_REQUEST, {}
+                if params.get('action') in ['previous', 'save_exit', 'next']:
+                    return response_data, status.HTTP_303_SEE_OTHER, {}
+        else:   # Form data were invalid.
+            return response_data, status.HTTP_400_BAD_REQUEST, {}
+
     return response_data, status.HTTP_200_OK, {}
 
 
 class LicenseForm(Form):
     """Generate form to select license."""
+
+    LICENSE_CHOICES = [(uri, data['label']) for uri, data in LICENSES.items()
+                       if data['is_current']] \
+        + [('',  'None of the above licenses apply')]
+
     license = RadioField(
         u'Select a license',
-        choices=[(license, data['label']) 
-                    for license, data in LICENSES.items() if data['is_current']]
-                + [('',  'None of the above licenses apply')],
+        choices=LICENSE_CHOICES,
         validators=[InputRequired('Please select a license')])

--- a/submit/controllers/license.py
+++ b/submit/controllers/license.py
@@ -91,4 +91,5 @@ class LicenseForm(Form):
     license = RadioField(
         u'Select a license',
         choices=LICENSE_CHOICES,
-        validators=[InputRequired('Please select a license')])
+        validators=[InputRequired('Please select a license')]
+    )

--- a/submit/controllers/tests/__init__.py
+++ b/submit/controllers/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for :mod:`submit.controllers`."""

--- a/submit/controllers/tests/test_authorship.py
+++ b/submit/controllers/tests/test_authorship.py
@@ -9,7 +9,7 @@ import events
 from submit.controllers.authorship import authorship, AuthorshipForm
 
 
-class TestVerifyUser(TestCase):
+class TestVerifyAuthorship(TestCase):
     """Test behavior of :func:`.authorship` controller."""
 
     @mock.patch('events.load')

--- a/submit/controllers/tests/test_license.py
+++ b/submit/controllers/tests/test_license.py
@@ -1,0 +1,111 @@
+"""Tests for :mod:`submit.controllers.license`."""
+
+from unittest import TestCase, mock
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError, NotFound
+from wtforms import Form
+from arxiv import status
+import events
+from submit.controllers.license import license, LicenseForm
+
+
+class TestVerifyUser(TestCase):
+    """Test behavior of :func:`.license` controller."""
+
+    @mock.patch('events.load')
+    def test_get_request_with_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        data, code, headers = license('GET', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.load')
+    def test_get_request_with_nonexistant_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+
+        def raise_no_such_submission(*args, **kwargs):
+            raise events.exceptions.NoSuchSubmission('Nada')
+
+        mock_load.side_effect = raise_no_such_submission
+        with self.assertRaises(NotFound):
+            license('GET', MultiDict(), submission_id)
+
+    @mock.patch('events.load')
+    def test_post_request(self, mock_load):
+        """POST request with no data."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        data, code, headers = license('POST', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('submit.controllers.util.url_for')
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_with_data(self, mock_load, mock_save, mock_url_for):
+        """POST request with `license` set."""
+        # Event store does not complain; returns object with `submission_id`.
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        mock_save.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        # `url_for` returns a URL (unsurprisingly).
+        redirect_url = 'https://foo.bar.com/yes'
+        mock_url_for.return_value = redirect_url
+
+        form_data = MultiDict({
+            'license': 'http://arxiv.org/licenses/nonexclusive-distrib/1.0/',
+            'action': 'next'
+        })
+        data, code, headers = license('POST', form_data, submission_id)
+        self.assertEqual(code, status.HTTP_303_SEE_OTHER,
+                         "Returns 303 redirect")
+        self.assertEqual(headers['Location'], redirect_url,
+                         "Location for redirect is set")
+
+    @mock.patch('submit.controllers.util.url_for')
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_select_fails(self, mock_load, mock_save, mock_url_for):
+        """Event store flakes out on license selection."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+
+        # Event store does not complain; returns object with `submission_id`
+        def raise_on_verify(*ev, **kwargs):
+            if type(ev[0]) is events.SelectLicense:
+                raise events.InvalidStack([
+                    events.InvalidEvent(ev[0], 'foo')
+                ])
+            return (
+                mock.MagicMock(submission_id=kwargs.get('submission_id', 2)),
+                []
+            )
+
+        mock_save.side_effect = raise_on_verify
+        form_data = MultiDict({
+            'license': 'http://arxiv.org/licenses/nonexclusive-distrib/1.0/',
+            'action': 'next'
+        })
+        data, code, headers = license('POST', form_data, 2)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+        self.assertIn("events", data["form"].errors,
+                      "Exception messages are added to form errors.")

--- a/submit/controllers/tests/test_license.py
+++ b/submit/controllers/tests/test_license.py
@@ -9,7 +9,7 @@ import events
 from submit.controllers.license import license, LicenseForm
 
 
-class TestVerifyUser(TestCase):
+class TestSelectLicense(TestCase):
     """Test behavior of :func:`.license` controller."""
 
     @mock.patch('events.load')

--- a/submit/controllers/tests/test_policy.py
+++ b/submit/controllers/tests/test_policy.py
@@ -1,0 +1,129 @@
+"""Tests for :mod:`submit.controllers.policy`."""
+
+from unittest import TestCase, mock
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError, NotFound
+from wtforms import Form
+from arxiv import status
+import events
+from submit.controllers.policy import policy, PolicyForm
+
+
+class TestAcceptPolicy(TestCase):
+    """Test behavior of :func:`.policy` controller."""
+
+    @mock.patch('events.load')
+    def test_get_request_with_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id,
+                           submitter_accepts_policy=False),
+            []
+        )
+        data, code, headers = policy('GET', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.load')
+    def test_get_request_with_nonexistant_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+
+        def raise_no_such_submission(*args, **kwargs):
+            raise events.exceptions.NoSuchSubmission('Nada')
+
+        mock_load.side_effect = raise_no_such_submission
+        with self.assertRaises(NotFound):
+            policy('GET', MultiDict(), submission_id)
+
+    @mock.patch('events.load')
+    def test_post_request(self, mock_load):
+        """POST request with no data."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id,
+                           submitter_accepts_policy=False),
+            []
+        )
+        data, code, headers = policy('POST', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.load')
+    def test_not_author_no_proxy(self, mock_load):
+        """User indicates they are not author, but also not proxy."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id,
+                           submitter_accepts_policy=False),
+            []
+        )
+        form_data = MultiDict({})
+        data, code, headers = policy('POST', form_data, submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('submit.controllers.util.url_for')
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_with_data(self, mock_load, mock_save, mock_url_for):
+        """POST request with `policy` set."""
+        # Event store does not complain; returns object with `submission_id`.
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id,
+                           submitter_accepts_policy=False),
+            []
+        )
+        mock_save.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        # `url_for` returns a URL (unsurprisingly).
+        redirect_url = 'https://foo.bar.com/yes'
+        mock_url_for.return_value = redirect_url
+
+        form_data = MultiDict({'policy': 'y', 'action': 'next'})
+        data, code, headers = policy('POST', form_data, submission_id)
+        self.assertEqual(code, status.HTTP_303_SEE_OTHER,
+                         "Returns 303 redirect")
+        self.assertEqual(headers['Location'], redirect_url,
+                         "Location for redirect is set")
+
+    @mock.patch('submit.controllers.util.url_for')
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_policy_fails(self, mock_load, mock_save, mock_url_for):
+        """Event store flakes out on policy acceptance."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id,
+                           submitter_accepts_policy=False),
+            []
+        )
+
+        # Event store does not complain; returns object with `submission_id`
+        def raise_on_policy(*ev, **kwargs):
+            if type(ev[0]) is events.AcceptPolicy:
+                raise events.InvalidStack([
+                    events.InvalidEvent(ev[0], 'foo')
+                ])
+            return (
+                mock.MagicMock(submission_id=kwargs.get('submission_id', 2)),
+                []
+            )
+
+        mock_save.side_effect = raise_on_policy
+        form_data = MultiDict({'policy': 'y', 'action': 'next'})
+        data, code, headers = policy('POST', form_data, 2)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+        self.assertIn("events", data["form"].errors,
+                      "Exception messages are added to form errors.")

--- a/submit/controllers/tests/test_verify_user.py
+++ b/submit/controllers/tests/test_verify_user.py
@@ -1,0 +1,98 @@
+"""Tests for :mod:`submit.controllers.verify_user`."""
+
+from unittest import TestCase, mock
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError
+from wtforms import Form
+from arxiv import status
+import events
+from submit.controllers.verify_user import verify_user
+
+
+class TestVerifyUser(TestCase):
+    """Test behavior of :func:`.verify_user` controller."""
+
+    def test_get_request(self):
+        """GET request with no submission ID."""
+        data, code, headers = verify_user('GET', MultiDict())
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    def test_get_request_with_submission(self):
+        """GET request with a submission ID."""
+        submission_id = 2
+        data, code, headers = verify_user('GET', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    def test_post_request(self):
+        """POST request with no data."""
+        submission_id = 2
+        data, code, headers = verify_user('POST', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('submit.controllers.util.url_for')
+    @mock.patch('events.save')
+    def test_post_request_with_data(self, mock_save, mock_url_for):
+        """POST request with `verify_user` set."""
+        # Event store does not complain; returns object with `submission_id`.
+        submission_id = 2
+        mock_save.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        # `url_for` returns a URL (unsurprisingly).
+        redirect_url = 'https://foo.bar.com/yes'
+        mock_url_for.return_value = redirect_url
+
+        form_data = MultiDict({'verify_user': 'y', 'action': 'next'})
+        data, code, headers = verify_user('POST', form_data, submission_id)
+        self.assertEqual(code, status.HTTP_303_SEE_OTHER,
+                         "Returns 303 redirect")
+        self.assertEqual(headers['Location'], redirect_url,
+                         "Location for redirect is set")
+
+    @mock.patch('submit.controllers.util.url_for')
+    @mock.patch('events.save')
+    def test_creation_fails(self, mock_save, mock_url_for):
+        """Event store flakes out on creation."""
+        # Event store does not complain; returns object with `submission_id`
+        def raise_on_creation(*ev):
+            if type(ev[0]) is events.CreateSubmission:
+                raise events.InvalidStack([
+                    events.InvalidEvent(ev[0], 'foo')
+                ])
+
+        mock_save.side_effect = raise_on_creation
+        form_data = MultiDict({'verify_user': 'y', 'action': 'next'})
+        with self.assertRaises(InternalServerError):
+            verify_user('POST', form_data)
+
+    @mock.patch('submit.controllers.util.url_for')
+    @mock.patch('events.save')
+    def test_verify_fails(self, mock_save, mock_url_for):
+        """Event store flakes out on user verification."""
+        # Event store does not complain; returns object with `submission_id`
+        def raise_on_verify(*ev, **kwargs):
+            if type(ev[0]) is events.VerifyContactInformation:
+                raise events.InvalidStack([
+                    events.InvalidEvent(ev[0], 'foo')
+                ])
+            return (
+                mock.MagicMock(submission_id=kwargs.get('submission_id', 2)),
+                []
+            )
+
+        mock_save.side_effect = raise_on_verify
+        form_data = MultiDict({'verify_user': 'y', 'action': 'next'})
+        data, code, headers = verify_user('POST', form_data)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+        self.assertIn("events", data["form"].errors,
+                      "Exception messages are added to form errors.")

--- a/submit/controllers/util.py
+++ b/submit/controllers/util.py
@@ -2,9 +2,10 @@
 
 from typing import Callable, Any, Dict, Tuple, Optional
 from werkzeug import MultiDict
-from werkzeug.exceptions import InternalServerError
+from werkzeug.exceptions import InternalServerError, NotFound
 from flask import url_for
 from arxiv import status
+import events
 
 Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
 
@@ -45,3 +46,28 @@ def flow_control(prev_page: str, next_page: str, exit_page: str) -> Callable:
             return data, status_code, headers
         return wrapper
     return deco
+
+
+def load_submission(submission_id: int) -> events.domain.Submission:
+    """
+    Load a submission by ID.
+
+    Parameters
+    ----------
+    submission_id : int
+
+    Returns
+    -------
+    :class:`events.domain.Submission`
+
+    Raises
+    ------
+    :class:`werkzeug.exceptions.NotFound`
+        Raised when there is no submission with the specified ID.
+
+    """
+    try:
+        submission, _ = events.load(submission_id)
+    except events.exceptions.NoSuchSubmission as e:
+        raise NotFound('No such submission.') from e
+    return submission

--- a/submit/controllers/verify_user.py
+++ b/submit/controllers/verify_user.py
@@ -6,6 +6,7 @@ Creates an event of type `core.events.event.VerifyContactInformation`
 
 from typing import Tuple, Dict, Any, Optional
 
+from werkzeug.exceptions import InternalServerError
 from flask import url_for
 from wtforms import Form, BooleanField
 from wtforms.validators import InputRequired
@@ -13,59 +14,73 @@ from wtforms.validators import InputRequired
 from arxiv import status
 from arxiv.base import logging
 import events
-from events.exceptions import InvalidEvent, SaveError
 
 from .util import flow_control
 
-logger = logging.getLogger(__name__) #pylint: disable=C0103
+logger = logging.getLogger(__name__)    #pylint: disable=C0103
 
-Response = Tuple[Dict[str, Any], int, Dict[str, Any]] #pylint: disable=C0103
+Response = Tuple[Dict[str, Any], int, Dict[str, Any]]    #pylint: disable=C0103
 
 
 @flow_control('ui.user', 'ui.authorship', 'ui.user')
-def verify_user(request_params: dict, submission_id: Optional[int]) -> Response:
+def verify_user(method: str, params: dict,
+                submission_id: Optional[int] = None) -> Response:
     """
-    Generate a `VerifyContactInformation` event.
+    Prompt the user to verify their contact information.
+
+    Generates a `VerifyContactInformation` event when valid data are POSTed.
 
     If a submission has not yet been created, the `CreateSubmission` event is
     raised to yield a submission_id.
     """
-    form = VerifyUserForm(request_params)
-    response_data = {'submission_id': submission_id}
+    logger.debug(f'method: {method}, submission: {submission_id}. {params}')
+    form = VerifyUserForm(params)
+    response_data = {'submission_id': submission_id, 'form': form}
 
-    # Process event if go to next page
-    if request_params.get('action') == 'next' and form.validate():
-        # TODO: Create a concrete User event from cookie info.
-        submitter = events.domain.User(1, email='ian413@cornell.edu',
-                                       forename='Ima', surname='Nauthor')
+    # Process event if go to next page.
+    if method == 'POST':
+        if form.validate() and form.verify_user.data:
+            logger.debug(f'Form is valid: {form.verify_user.data}')
+            # TODO: Create a concrete User from cookie info.
+            submitter = events.domain.User(1, email='ian413@cornell.edu',
+                                           forename='Ima', surname='Nauthor')
 
-        # Create submission if it does not yet exist
-        try:
+            # Create submission if it does not yet exist.
             if submission_id is None:
-                submission, _ = events.save(
-                    events.CreateSubmission(creator=submitter)
-                )
-                submission_id = submission.submission_id
-        except SaveError:
-            # TODO: review exception raising for 5XX errors.
-            return {}, status.HTTP_503_SERVICE_UNAVAILABLE, {}
+                logger.debug('No submission ID; creating a new submission')
+                try:
+                    submission, _ = events.save(
+                        events.CreateSubmission(creator=submitter)
+                    )
+                    submission_id = submission.submission_id
+                except events.exceptions.InvalidStack as e:
+                    logger.error('Could not create submission: %s', e)
+                    # Creation requires basically no information, so this is
+                    # likely unrecoverable.
+                    raise InternalServerError('Creation failed') from e
 
-        try:
-            # Create VerifyContactInformation event
-            submission, _ = events.save(
-                events.VerifyContactInformation(creator=submitter),
-                submission_id=submission_id
-            )
-        except InvalidEvent:
-            # TODO: Pass along the errors better
-            return {}, status.HTTP_400_BAD_REQUEST, {}
+            # Now that we have a submission, we can verify the user's contact
+            # information.
+            logger.debug('Submission ID: %s', str(submission_id))
+            try:    # Create VerifyContactInformation event
+                submission, _ = events.save(
+                    events.VerifyContactInformation(creator=submitter),
+                    submission_id=submission_id
+                )
+            except events.exceptions.InvalidStack as e:
+                logger.error('Could not perform VerifyContactInformation: %s',
+                             str(e))
+                form.errors     # Causes the form to initialize errors.
+                form._errors['events'] = [ie.message for ie
+                                          in e.event_exceptions]
+                return response_data, status.HTTP_400_BAD_REQUEST, {}
+
+        # Either the form data were invalid, or the user did not check the
+        # "verify" box.
+        else:
+            return response_data, status.HTTP_400_BAD_REQUEST, {}
         response_data.update({'submission_id': submission_id})
         return response_data, status.HTTP_303_SEE_OTHER, {}
-
-    # build response form
-    response_data.update({'form': form})
-    logger.debug(f'verify_user data: {form}')
-
     return response_data, status.HTTP_200_OK, {}
 
 

--- a/submit/controllers/verify_user.py
+++ b/submit/controllers/verify_user.py
@@ -6,7 +6,8 @@ Creates an event of type `core.events.event.VerifyContactInformation`
 
 from typing import Tuple, Dict, Any, Optional
 
-from werkzeug.exceptions import InternalServerError
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError, NotFound
 from flask import url_for
 from wtforms import Form, BooleanField
 from wtforms.validators import InputRequired
@@ -15,15 +16,48 @@ from arxiv import status
 from arxiv.base import logging
 import events
 
-from .util import flow_control
+from .util import flow_control, load_submission
 
 logger = logging.getLogger(__name__)    #pylint: disable=C0103
 
 Response = Tuple[Dict[str, Any], int, Dict[str, Any]]    #pylint: disable=C0103
 
 
+def _create_submission(user: events.domain.User,
+                       client: Optional[events.domain.Client] = None) \
+        -> events.domain.Submission:
+    """
+    Create a new submission.
+
+    Parameters
+    ----------
+    user : :class:`events.domain.User`
+    client : :class:`events.domain.Client`
+
+    Returns
+    -------
+    :class:`events.domain.Submission`
+
+    Raises
+    ------
+    :class:`werkzeug.exceptions.NotFound`
+        Raised when there is no submission with the specified ID.
+
+    """
+    try:
+        submission, _ = events.save(
+            events.CreateSubmission(creator=user, client=client)
+        )
+    except events.exceptions.InvalidStack as e:
+        logger.error('Could not create submission: %s', e)
+        # Creation requires basically no information, so this is
+        # likely unrecoverable.
+        raise InternalServerError('Creation failed') from e
+    return submission
+
+
 @flow_control('ui.user', 'ui.authorship', 'ui.user')
-def verify_user(method: str, params: dict,
+def verify_user(method: str, params: MultiDict,
                 submission_id: Optional[int] = None) -> Response:
     """
     Prompt the user to verify their contact information.
@@ -34,6 +68,15 @@ def verify_user(method: str, params: dict,
     raised to yield a submission_id.
     """
     logger.debug(f'method: {method}, submission: {submission_id}. {params}')
+
+    if submission_id:
+        # Will raise NotFound if there is no such submission.
+        submission = load_submission(submission_id)
+
+        # Initialize the form with the current state of the submission.
+        if method == 'GET':
+            params['verify_user'] = submission.submitter_contact_verified
+
     form = VerifyUserForm(params)
     response_data = {'submission_id': submission_id, 'form': form}
 
@@ -48,32 +91,27 @@ def verify_user(method: str, params: dict,
             # Create submission if it does not yet exist.
             if submission_id is None:
                 logger.debug('No submission ID; creating a new submission')
-                try:
-                    submission, _ = events.save(
-                        events.CreateSubmission(creator=submitter)
-                    )
-                    submission_id = submission.submission_id
-                except events.exceptions.InvalidStack as e:
-                    logger.error('Could not create submission: %s', e)
-                    # Creation requires basically no information, so this is
-                    # likely unrecoverable.
-                    raise InternalServerError('Creation failed') from e
+                submission = _create_submission(submitter)
+                submission_id = submission.submission_id
 
             # Now that we have a submission, we can verify the user's contact
             # information.
             logger.debug('Submission ID: %s', str(submission_id))
-            try:    # Create VerifyContactInformation event
-                submission, _ = events.save(
-                    events.VerifyContactInformation(creator=submitter),
-                    submission_id=submission_id
-                )
-            except events.exceptions.InvalidStack as e:
-                logger.error('Could not perform VerifyContactInformation: %s',
-                             str(e))
-                form.errors     # Causes the form to initialize errors.
-                form._errors['events'] = [ie.message for ie
-                                          in e.event_exceptions]
-                return response_data, status.HTTP_400_BAD_REQUEST, {}
+
+            # There is no need to do this more than once.
+            if not submission.submitter_contact_verified:
+                try:    # Create VerifyContactInformation event
+                    submission, _ = events.save(
+                        events.VerifyContactInformation(creator=submitter),
+                        submission_id=submission_id
+                    )
+                except events.exceptions.InvalidStack as e:
+                    logger.error('Could not VerifyContactInformation: %s',
+                                 str(e))
+                    form.errors     # Causes the form to initialize errors.
+                    form._errors['events'] = [ie.message for ie
+                                              in e.event_exceptions]
+                    return response_data, status.HTTP_400_BAD_REQUEST, {}
 
         # Either the form data were invalid, or the user did not check the
         # "verify" box.

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -60,13 +60,15 @@ def authorship(submission_id):
 @blueprint.route('/<int:submission_id>/license', methods=['GET', 'POST'])
 def license(submission_id):
     """Render step 3, select license."""
-    response, code, headers = controllers.license(request.args, submission_id)
+    request_data = MultiDict(request.form.items(multi=True))
+    data, code, headers = controllers.license(request.method, request_data,
+                                              submission_id)
 
-    if code == status.HTTP_200_OK:
+    if code in [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST]:
         rendered = render_template(
             "submit/license.html",
             pagetitle='Select a License',
-            **response
+            **data
         )
         response = make_response(rendered, status.HTTP_200_OK)
         return response

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -1,5 +1,6 @@
 """Provides routes for the submission user interface."""
 
+from typing import Optional
 from flask import (Blueprint, make_response, redirect, request,
                    render_template, url_for)
 from arxiv import status
@@ -19,15 +20,15 @@ def user():
 
 @blueprint.route('/create', methods=['GET', 'POST'])
 @blueprint.route('/<int:submission_id>/verify_user', methods=['GET', 'POST'])
-def verify_user(submission_id=None):
+def verify_user(submission_id: Optional[int] = None):
     """Render the submit start page. Foreshortened validation for testing."""
-    response, code, headers = controllers.verify_user(request.args, submission_id)
-    print(response, code, headers)
-    if code == status.HTTP_200_OK:
+    data, code, headers = controllers.verify_user(request.method, request.form,
+                                                  submission_id)
+    if code in [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST]:
         rendered = render_template(
             "submit/verify_user.html",
             pagetitle='Verify User Information',
-            **response
+            **data
         )
         response = make_response(rendered, status.HTTP_200_OK)
         return response

--- a/submit/templates/submit/authorship.html
+++ b/submit/templates/submit/authorship.html
@@ -4,36 +4,36 @@
 
 {% block within_content %}
 <h2 class="is-size-4">Confirm authorship or proxy approval</h2>
-<form method="GET" action="{{ url_for('ui.authorship',submission_id=submission_id) }}">
-{% for field in form.authorship %}
-  <div class="field">
-    <div class="control">
-      <div class="radio">
-        {{ field|safe }}
-        {{ field.label }}
+<form method="POST" action="{{ url_for('ui.authorship',submission_id=submission_id) }}">
+  {% for field in form.authorship %}
+    <div class="field">
+      <div class="control">
+        <div class="radio">
+          {{ field|safe }}
+          {{ field.label }}
+        </div>
       </div>
     </div>
-  </div>
-{% endfor %}
-{% if form.authorship.errors %}
-  {% for error in form.authorship.errors %}
-    <p class="help is-warning">{{ error }}</p>
   {% endfor %}
-{% endif %}
+  {% if form.authorship.errors %}
+    {% for error in form.authorship.errors %}
+      <p class="help is-warning">{{ error }}</p>
+    {% endfor %}
+  {% endif %}
 
-<div class="field">
-  <div class="control" style="margin-left: 1.25em">
-    <div class="checkbox">
-      {{ form.proxy }}
-      {{ form.proxy.label }} <a href="help link as modal"><i class="fa fa-question-circle is-info"></i></a>
+  <div class="field">
+    <div class="control" style="margin-left: 1.25em">
+      <div class="checkbox">
+        {{ form.proxy }}
+        {{ form.proxy.label }} <a href="help link as modal"><i class="fa fa-question-circle is-info"></i></a>
+      </div>
+      {% if form.proxy.errors %}
+        {% for error in form.proxy.errors %}
+          <p class="help is-warning">{{ error }}</p>
+        {% endfor %}
+      {% endif %}
     </div>
-    {% if form.proxy.errors %}
-      {% for error in form.proxy.errors %}
-        <p class="help is-warning">{{ error }}</p>
-      {% endfor %}
-    {% endif %}
   </div>
-</div>
 
 {{ submit_macros.submit_nav() }}
 </form>

--- a/submit/templates/submit/base.html
+++ b/submit/templates/submit/base.html
@@ -12,6 +12,15 @@
   </div>
   </div>
   <content>
+    {% if form and form.errors %}
+      {% if form.errors.events %}
+      <div class="notification is-warning">
+        {% for error in form.errors.events %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </div>
+      {% endif %}
+    {% endif %}
     {% block within_content %}
       Specific content here
     {% endblock within_content %}

--- a/submit/templates/submit/license.html
+++ b/submit/templates/submit/license.html
@@ -15,7 +15,7 @@
       {% if subfield.data %}
           <a href="{{subfield.data}}">{{ subfield.label.text }}</a>
       {% else %}
-          {{subfield.label}}
+          {{subfield.label.text }}
       {% endif %}
       </label>
     </div>

--- a/submit/templates/submit/license.html
+++ b/submit/templates/submit/license.html
@@ -9,10 +9,11 @@
   <div class="field">
   {% for subfield in form.license %}
     <div class="control">
+
       <label class="radio">
-      {{subfield}}
+        {{subfield}}
       {% if subfield.data %}
-          <a href="{{subfield.data}}">{{subfield.label}}</a>
+          <a href="{{subfield.data}}">{{ subfield.label.text }}</a>
       {% else %}
           {{subfield.label}}
       {% endif %}

--- a/submit/templates/submit/license.html
+++ b/submit/templates/submit/license.html
@@ -5,28 +5,28 @@
 {% block within_content %}
 <h2 class="is-size-4">Select a license</h2>
 
-<form method="GET" action="{{ url_for('ui.license',submission_id=submission_id) }}">
-<div class="field">
-{% for subfield in form.license %}
-  <div class="control">
-    <label class="radio">
-    {{subfield}}
-    {% if subfield.data %}
-        <a href="{{subfield.data}}">{{subfield.label}}</a>
-    {% else %}
-        {{subfield.label}}
-    {% endif %}
-    </label>
-  </div>
-{% endfor %}
-</div>
-
-{% if form.license.errors %}
-  {% for error in form.license.errors %}
-    <p class="help is-warning">{{ error }}</p>
+<form method="POST" action="{{ url_for('ui.license',submission_id=submission_id) }}">
+  <div class="field">
+  {% for subfield in form.license %}
+    <div class="control">
+      <label class="radio">
+      {{subfield}}
+      {% if subfield.data %}
+          <a href="{{subfield.data}}">{{subfield.label}}</a>
+      {% else %}
+          {{subfield.label}}
+      {% endif %}
+      </label>
+    </div>
   {% endfor %}
-{% endif %}
+  </div>
 
-{{ submit_macros.submit_nav() }}
+  {% if form.license.errors %}
+    {% for error in form.license.errors %}
+      <p class="help is-warning">{{ error }}</p>
+    {% endfor %}
+  {% endif %}
+
+  {{ submit_macros.submit_nav() }}
 </form>
 {% endblock within_content %}

--- a/submit/templates/submit/policy.html
+++ b/submit/templates/submit/policy.html
@@ -14,7 +14,7 @@
   <li>For third-party submissions, I have obtained pre-authorization from arXiv
     to submit as a third-party submitter.</li>
 </ul>
-<form method="POST" action="{{ url_for('ui.policy',submission_id=submission_id) }}">
+<form method="POST" action="{{ url_for('ui.policy', submission_id=submission_id) }}">
   <div class="field">
     <div class="control">
       <div class="checkbox">

--- a/submit/templates/submit/policy.html
+++ b/submit/templates/submit/policy.html
@@ -14,19 +14,19 @@
   <li>For third-party submissions, I have obtained pre-authorization from arXiv
     to submit as a third-party submitter.</li>
 </ul>
-<form method="GET" action="{{ url_for('ui.policy',submission_id=submission_id) }}">
-<div class="field">
-  <div class="control">
-    <div class="checkbox">
-      {{ form.policy }}
-      {{ form.policy.label }}
+<form method="POST" action="{{ url_for('ui.policy',submission_id=submission_id) }}">
+  <div class="field">
+    <div class="control">
+      <div class="checkbox">
+        {{ form.policy }}
+        {{ form.policy.label }}
+      </div>
+      {% for error in form.policy.errors %}
+        <p class="help is-warning">{{ error }}</p>
+      {% endfor %}
     </div>
-    {% for error in form.policy.errors %}
-      <p class="help is-warning">{{ error }}</p>
-    {% endfor %}
   </div>
-</div>
 
-{{ submit_macros.submit_nav() }}
+  {{ submit_macros.submit_nav() }}
 </form>
 {% endblock within_content %}

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -3,23 +3,35 @@
 {% import "submit/submit_macros.html" as submit_macros %}
 
 {% block within_content %}
+
+{% if form.errors %}
+  {% if form.errors.events %}
+  <div class="notification is-warning">
+    {% for error in form.errors.events %}
+    <li>{{ error }}</li>
+    {% endfor %}
+  </div>
+  {% endif %}
+{% endif %}
+
 <h2 class="is-size-4">Verify your contact information</h2>
 <p><span class="label">Forename:</span> Ima</p>
 <p><span class="label">Surname:</span> Nauthor</p>
 <p><span class="label">Suffix:</span></p>
 <p><span class="label">Affiliation:</span> Cornell University</p>
 <p><span class="label">E-mail:</span> ian413@cornell.edu</p>
-<form method="GET" action="{{ url_for('ui.verify_user') }}">
-<div class="field">
-  <div class="control">
-    <div class="checkbox">
-      {{ form.verify_user }}
-      {{ form.verify_user.label }}
+
+<form method="POST" action="{{ url_for('ui.verify_user') }}">
+  <div class="field">
+    <div class="control">
+      <div class="checkbox">
+        {{ form.verify_user }}
+        {{ form.verify_user.label }}
+      </div>
+      {% for error in form.verify_user.errors %}
+        <p class="help is-warning">{{ error }}</p>
+      {% endfor %}
     </div>
-    {% for error in form.verify_user.errors %}
-      <p class="help is-warning">{{ error }}</p>
-    {% endfor %}
-  </div>
 </div>
 
 {{ submit_macros.submit_nav() }}

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -4,16 +4,6 @@
 
 {% block within_content %}
 
-{% if form.errors %}
-  {% if form.errors.events %}
-  <div class="notification is-warning">
-    {% for error in form.errors.events %}
-    <li>{{ error }}</li>
-    {% endfor %}
-  </div>
-  {% endif %}
-{% endif %}
-
 <h2 class="is-size-4">Verify your contact information</h2>
 <p><span class="label">Forename:</span> Ima</p>
 <p><span class="label">Surname:</span> Nauthor</p>


### PR DESCRIPTION
This also contributes to ARXIVNG-911 by changing the form request method on verify_user to POST.

The basic idea is that we are catching ``InvalidStack``, and displaying the exception messages on its constituent ``InvalidEvent``s at the top of the page. Here's a mockup (not real exceptions):

<img width="984" alt="screen shot 2018-06-15 at 8 43 08 am" src="https://user-images.githubusercontent.com/3451594/41468779-0f835102-7079-11e8-9019-4a031e498cfd.png">

In addition, we should leverage the event's own validation on the form. Will do this next.