### PR TITLE
ARXIVNG-877 add cross-list functionality (secondary classification)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ WTForms = "==2.1"
 PyYAML = "*"
 pytz = "*"
 SQLAlchemy = "*"
-"3a3786f" = {path = "./../arxiv-submission-core/core"}
 arxiv-submission-events = "==0.2.3"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ WTForms = "==2.1"
 PyYAML = "*"
 pytz = "*"
 SQLAlchemy = "*"
-arxiv-submission-events = "==0.2.2"
+"3a3786f" = {path = "./../arxiv-submission-core/core"}
 
 [dev-packages]
 "nose2" = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ PyYAML = "*"
 pytz = "*"
 SQLAlchemy = "*"
 "3a3786f" = {path = "./../arxiv-submission-core/core"}
+arxiv-submission-events = "==0.2.3"
 
 [dev-packages]
 "nose2" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0bace5b5ec85941f08472ea56f72b3ec4cb6a02cbd7f174105db16df1678df3c"
+            "sha256": "2b2cc009fbf1fa3b7666e6ac39db01fbc8247ce9e014c3ccc48322f446f7e1e6"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,6 +23,13 @@
             ],
             "index": "pypi",
             "version": "==0.7.1"
+        },
+        "arxiv-submission-events": {
+            "hashes": [
+                "sha256:fb626773d72e3f1cba38f0757ee98a8b436516c524335a1b2c8b67411a177e4b"
+            ],
+            "index": "pypi",
+            "version": "==0.2.3"
         },
         "click": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2b2cc009fbf1fa3b7666e6ac39db01fbc8247ce9e014c3ccc48322f446f7e1e6"
+            "sha256": "701c9d6f390e33303dd02024dfef6bb9bfe47faea04ec1357e3cd2af37e5ae59"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,9 +14,6 @@
         ]
     },
     "default": {
-        "3a3786f": {
-            "path": "./../arxiv-submission-core/core"
-        },
         "arxiv-base": {
             "hashes": [
                 "sha256:e386f771296d2971d0435640a732dc3c77c4f7856ddabfe0daba9e3bafbd6dfb"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "847488adddfcd6e68990614d82d8848a4ca7efcb9ce8b181851c972757a8785a"
+            "sha256": "0bace5b5ec85941f08472ea56f72b3ec4cb6a02cbd7f174105db16df1678df3c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,19 +14,15 @@
         ]
     },
     "default": {
+        "3a3786f": {
+            "path": "./../arxiv-submission-core/core"
+        },
         "arxiv-base": {
             "hashes": [
                 "sha256:e386f771296d2971d0435640a732dc3c77c4f7856ddabfe0daba9e3bafbd6dfb"
             ],
             "index": "pypi",
             "version": "==0.7.1"
-        },
-        "arxiv-submission-events": {
-            "hashes": [
-                "sha256:9d1a3ff1a5b45b2501ecc56d776392f1c658206a14f0cf556321a19ff26686dd"
-            ],
-            "index": "pypi",
-            "version": "==0.2.2"
         },
         "click": {
             "hashes": [

--- a/submit/controllers/__init__.py
+++ b/submit/controllers/__init__.py
@@ -2,7 +2,7 @@ from .verify_user import verify_user
 from .authorship import authorship
 from .license import license
 from .policy import policy
-from .classification import classification, crosslist
+from .classification import classification, cross_list
 
 __all__ = ['verify_user', 'authorship', 'license', 'policy', 'classification',
-           'crosslist']
+           'cross_list']

--- a/submit/controllers/__init__.py
+++ b/submit/controllers/__init__.py
@@ -1,8 +1,10 @@
+"""Request controllers for the submission UI."""
+
 from .verify_user import verify_user
 from .authorship import authorship
 from .license import license
 from .policy import policy
 from .classification import classification, cross_list
 
-__all__ = ['verify_user', 'authorship', 'license', 'policy', 'classification',
-           'cross_list']
+__all__ = ('verify_user', 'authorship', 'license', 'policy', 'classification',
+           'cross_list')

--- a/submit/controllers/authorship.py
+++ b/submit/controllers/authorship.py
@@ -42,7 +42,7 @@ def _data_from_submission(params: MultiDict,
 
 
 @flow_control('ui.verify_user', 'ui.license', 'ui.user')
-def authorship(method: str, params: dict, submission_id: int,
+def authorship(method: str, params: MultiDict, submission_id: int,
                user: Optional[events.domain.User] = None,
                client: Optional[events.domain.Client] = None) -> Response:
     """Convert authorship form data into an `AssertAuthorship` event."""
@@ -114,7 +114,7 @@ class AuthorshipForm(Form):
                          'on behalf of the author(s).',
                          validators=[optional()])
 
-    def validate_authorship(self, field):
+    def validate_authorship(self, field: RadioField) -> None:
         """Require proxy field if submitter is not author."""
         if field.data == self.NO and not self.data.get('proxy'):
                 raise ValidationError('You must get prior approval to submit '

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -4,11 +4,11 @@ Controller for classification actinos.
 Creates an event of type `core.events.event.SetPrimaryClassification`
 Creates an event of type `core.events.event.AddSecondaryClassification`
 """
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict, Any, List
 from werkzeug import MultiDict
 from werkzeug.exceptions import InternalServerError
 from flask import url_for
-from wtforms import Form
+from wtforms import Form, SelectField, widgets, HiddenField
 
 from arxiv import status, taxonomy
 from arxiv.base import logging
@@ -22,6 +22,30 @@ logger = logging.getLogger(__name__)  # pylint: disable=C0103
 Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
 
 
+class ClassificationForm(Form):
+    """Form for classification selection."""
+
+    CATEGORIES = [
+        (archive['name'], [
+            (category_id, category['name'])
+            for category_id, category in taxonomy.CATEGORIES.items()
+            if category['is_active'] and category['in_archive'] == archive_id
+        ])
+        for archive_id, archive in taxonomy.ARCHIVES.items()
+        if 'end_date' not in archive
+    ]
+    """Categories grouped by archive."""
+
+    ADD = 'add'
+    REMOVE = 'remove'
+    OPERATIONS = [
+        (ADD, 'Add'),
+        (REMOVE, 'Remove')
+    ]
+    operation = HiddenField(default=ADD)
+    category = OptGroupSelectField('Category', choices=CATEGORIES, default='')
+
+
 def _data_from_submission(params: MultiDict,
                           submission: events.domain.Submission) -> MultiDict:
     if submission.primary_classification \
@@ -30,7 +54,40 @@ def _data_from_submission(params: MultiDict,
     return params
 
 
-@flow_control('ui.policy', 'ui.crosslist', 'ui.user')
+def _formset_from_submission(submission: events.domain.Submission) \
+        -> Dict[str, Tuple[str, ClassificationForm]]:
+    """Generate a set of forms used to remove cross-lists in the template."""
+    formset = {}
+    if hasattr(submission, 'secondary_classification') and \
+            submission.secondary_classification:
+        for secondary in submission.secondary_classification:
+            this_category = str(secondary.category)
+            subform = ClassificationForm(operation=ClassificationForm.REMOVE,
+                                         category=this_category)
+            subform.category.widget = widgets.HiddenInput()
+            display = taxonomy.CATEGORIES.get(this_category, {}).get('name')
+            formset[secondary.category] = (display, subform)
+    return formset
+
+
+def _filter_choices(form: ClassificationForm,
+                    submission: events.domain.Submission) -> None:
+    """Remove primaries and secondaries from category choices."""
+    selected = form.category.data
+    secondaries = [kls.category for kls in submission.secondary_classification]
+
+    form.category.choices = [
+        (archive, [
+            (category, display) for category, display in archive_choices
+            if (category != submission.primary_classification.category
+                and category not in secondaries)
+            or category == selected
+        ])
+        for archive, archive_choices in form.category.choices
+    ]
+
+
+@flow_control('ui.policy', 'ui.cross_list', 'ui.user')
 def classification(method: str, params: MultiDict,
                    submission_id: int) -> Response:
     """Generate a `SetPrimaryClassification` event."""
@@ -46,7 +103,9 @@ def classification(method: str, params: MultiDict,
     if method == 'GET':
         params = _data_from_submission(params, submission)
 
-    form = PrimaryClassificationForm(params)
+    params['operation'] = ClassificationForm.ADD     # Always add a primary.
+
+    form = ClassificationForm(params)
     response_data = {'submission_id': submission_id, 'form': form}
 
     if method == 'POST':
@@ -87,40 +146,71 @@ def classification(method: str, params: MultiDict,
 
 
 @flow_control('ui.classification', 'ui.upload', 'ui.user')
-def crosslist(params: dict, submission_id: int) -> Response:
-    """Generate a `AddSecondaryClassification` event."""
-    form = SecondaryClassificationForm(params)
+def cross_list(method: str, params: MultiDict, submission_id: int) -> Response:
+    """Generate an `AddSecondaryClassification` event."""
+    # TODO: Create a concrete User from cookie info.
+    submitter = events.domain.User(1, email='ian413@cornell.edu',
+                                   forename='Ima', surname='Nauthor')
 
-    # Process event if go to next page
-    action = params.get('action')
-    if action in ['previous', 'save_exit', 'next'] and form.validate():
-        # TODO: Write submission info
-        pass
+    # Will raise NotFound if there is no such submission.
+    submission = load_submission(submission_id)
 
-    # build response form
-    response_data = {'form': form, 'submission_id': submission_id}
-    logger.debug(f'verify_user data: {form}')
+    # We need forms for existing secondaries, to generate removal requests.
+    formset = _formset_from_submission(submission)
 
+    # This form handles additions and removals.
+    form = ClassificationForm(params)
+    form.operation._value = lambda: form.operation.data
+    _filter_choices(form, submission)
+    response_data = {'submission_id': submission_id, 'form': form,
+                     'formset': formset}
+
+    if method == 'POST':
+        if form.validate():
+            logger.debug('Form is valid, with data: %s', str(form.data))
+            category = form.category.data
+            operation = form.operation.data
+            try:
+                if operation == ClassificationForm.REMOVE:
+                    submission, stack = events.save(  # pylint: disable=W0612
+                        events.RemoveSecondaryClassification(
+                            creator=submitter,
+                            category=category
+                        ),
+                        submission_id=submission_id
+                    )
+                elif operation == ClassificationForm.ADD:
+                    submission, stack = events.save(  # pylint: disable=W0612
+                        events.AddSecondaryClassification(creator=submitter,
+                                                          category=category),
+                        submission_id=submission_id
+                    )
+            except events.exceptions.InvalidStack as e:
+                logger.error('Could not add secondary: %s', str(e))
+                form.errors     # Causes the form to initialize errors.
+                form._errors['events'] = [ie.message for ie
+                                          in e.event_exceptions]
+                logger.debug('InvalidStack; return bad request')
+                return response_data, status.HTTP_400_BAD_REQUEST, {}
+            except events.exceptions.SaveError as e:
+                logger.error('Could not save primary event')
+                raise InternalServerError(
+                    'There was a problem saving this operation'
+                ) from e
+
+            # Re-build the formset, to reflect changes that we just made.
+            response_data['formset'] = _formset_from_submission(submission)
+            # We want a fresh form here, since the POSTed data should now
+            # be reflected in the formset.
+            form = ClassificationForm()
+            form.operation._value = lambda: form.operation.data
+            _filter_choices(form, submission)
+            response_data['form'] = form
+        else:   # Form data were invalid.
+            logger.debug('Invalid form data; return bad request')
+            return response_data, status.HTTP_400_BAD_REQUEST, {}
+    if params.get('action') in ['previous', 'save_exit', 'next']:
+        logger.debug('Redirect to %s', params.get('action'))
+        return response_data, status.HTTP_303_SEE_OTHER, {}
+    logger.debug('Nothing to do, return 200')
     return response_data, status.HTTP_200_OK, {}
-
-
-class PrimaryClassificationForm(Form):
-    """Form for primary classification selection."""
-
-    CATEGORIES = [
-        (archive['name'], [
-            (category_id, category['name'])
-            for category_id, category in taxonomy.CATEGORIES.items()
-            if category['is_active'] and category['in_archive'] == archive_id
-        ])
-        for archive_id, archive in taxonomy.ARCHIVES.items()
-        if 'end_date' not in archive
-    ]
-    """Categories grouped by archive."""
-
-    category = OptGroupSelectField('Primary category', choices=CATEGORIES,
-                                   default='')
-
-
-class SecondaryClassificationForm(Form):
-    """Form for secondary classification selection"""

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -145,7 +145,7 @@ def classification(method: str, params: MultiDict,
     return response_data, status.HTTP_200_OK, {}
 
 
-@flow_control('ui.classification', 'ui.upload', 'ui.user')
+@flow_control('ui.classification', 'ui.file_upload', 'ui.user')
 def cross_list(method: str, params: MultiDict, submission_id: int) -> Response:
     """Generate an `AddSecondaryClassification` event."""
     # TODO: Create a concrete User from cookie info.

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -79,7 +79,8 @@ def _filter_choices(form: ClassificationForm,
     form.category.choices = [
         (archive, [
             (category, display) for category, display in archive_choices
-            if (category != submission.primary_classification.category
+            if ((not submission.primary_classification
+                 or category != submission.primary_classification.category)
                 and category not in secondaries)
             or category == selected
         ])

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -106,7 +106,10 @@ def classification(method: str, params: MultiDict,
     params['operation'] = ClassificationForm.ADD     # Always add a primary.
 
     form = ClassificationForm(params)
-    response_data = {'submission_id': submission_id, 'form': form}
+    response_data = {
+        'submission_id': submission_id,
+        'form': form
+    }
 
     if method == 'POST':
         if form.validate():
@@ -164,8 +167,15 @@ def cross_list(method: str, params: MultiDict, submission_id: int) -> Response:
     form = ClassificationForm(params)
     form.operation._value = lambda: form.operation.data
     _filter_choices(form, submission)
-    response_data = {'submission_id': submission_id, 'form': form,
-                     'formset': formset}
+    response_data = {
+        'submission_id': submission_id,
+        'form': form,
+        'formset': formset,
+        'primary': {
+            'id': submission.primary_classification.category,
+            'name': taxonomy.CATEGORIES[submission.primary_classification.category]['name']
+        }
+    }
 
     if method == 'POST':
         if form.validate():

--- a/submit/controllers/tests/test_classification.py
+++ b/submit/controllers/tests/test_classification.py
@@ -1,0 +1,202 @@
+"""Tests for :mod:`submit.controllers.classification`."""
+
+from unittest import TestCase, mock
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError, NotFound
+from wtforms import Form
+from arxiv import status
+import events
+from submit.controllers.classification import classification, cross_list, \
+    ClassificationForm
+
+
+class TestClassification(TestCase):
+    """Test behavior of :func:`.classification` controller."""
+
+    @mock.patch('events.load')
+    def test_get_request_with_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        data, code, headers = classification('GET', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.load')
+    def test_get_request_with_nonexistant_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+
+        def raise_no_such_submission(*args, **kwargs):
+            raise events.exceptions.NoSuchSubmission('Nada')
+
+        mock_load.side_effect = raise_no_such_submission
+        with self.assertRaises(NotFound):
+            classification('GET', MultiDict(), submission_id)
+
+    @mock.patch('events.load')
+    def test_post_request(self, mock_load):
+        """POST request with no data."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        data, code, headers = classification('POST', MultiDict(),
+                                             submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_with_invalid_category(self, mock_load, mock_save):
+        """POST request with invalid category."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        mock_save.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        request_data = MultiDict({
+            'category': 'astro-ph'  # <- expired
+        })
+        data, code, headers = classification('POST', request_data,
+                                             submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_with_category(self, mock_load, mock_save):
+        """POST request with valid category."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        mock_save.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        request_data = MultiDict({
+            'category': 'astro-ph.CO'
+        })
+        data, code, headers = classification('POST', request_data,
+                                             submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+
+class TestCrossList(TestCase):
+    """Test behavior of :func:`.cross_list` controller."""
+
+    @mock.patch('events.load')
+    def test_get_request_with_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(
+                submission_id=submission_id,
+                primary_classification=mock.MagicMock(
+                    category='astro-ph.EP'
+                )
+            ), []
+        )
+        data, code, headers = cross_list('GET', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.load')
+    def test_get_request_with_nonexistant_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+
+        def raise_no_such_submission(*args, **kwargs):
+            raise events.exceptions.NoSuchSubmission('Nada')
+
+        mock_load.side_effect = raise_no_such_submission
+        with self.assertRaises(NotFound):
+            cross_list('GET', MultiDict(), submission_id)
+
+    @mock.patch('events.load')
+    def test_post_request(self, mock_load):
+        """POST request with no data."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(
+                submission_id=submission_id,
+                primary_classification=mock.MagicMock(
+                    category='astro-ph.EP'
+                )
+            ), []
+        )
+        data, code, headers = cross_list('POST', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_with_invalid_category(self, mock_load, mock_save):
+        """POST request with invalid category."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(
+                submission_id=submission_id,
+                primary_classification=mock.MagicMock(
+                    category='astro-ph.EP'
+                )
+            ), []
+        )
+        mock_save.return_value = (
+            mock.MagicMock(
+                submission_id=submission_id,
+                primary_classification=mock.MagicMock(
+                    category='astro-ph.EP'
+                )
+            ), []
+        )
+        request_data = MultiDict({
+            'category': 'astro-ph'  # <- expired
+        })
+        data, code, headers = classification('POST', request_data,
+                                             submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_with_category(self, mock_load, mock_save):
+        """POST request with valid category."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(
+                submission_id=submission_id,
+                primary_classification=mock.MagicMock(
+                    category='astro-ph.EP'
+                )
+            ), []
+        )
+        mock_save.return_value = (
+            mock.MagicMock(
+                submission_id=submission_id,
+                primary_classification=mock.MagicMock(
+                    category='astro-ph.EP'
+                )
+            ), []
+        )
+        request_data = MultiDict({'category': 'astro-ph.CO'})
+        data, code, headers = cross_list('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")

--- a/submit/controllers/tests/test_primary.py
+++ b/submit/controllers/tests/test_primary.py
@@ -6,7 +6,8 @@ from werkzeug.exceptions import InternalServerError, NotFound
 from wtforms import Form
 from arxiv import status
 import events
-from submit.controllers.classification import classification, PrimaryClassificationForm
+from submit.controllers.classification import classification, \
+    ClassificationForm
 
 
 class TestSetPrimaryClassification(TestCase):

--- a/submit/controllers/util.py
+++ b/submit/controllers/util.py
@@ -109,3 +109,6 @@ class OptGroupSelectField(SelectField):
                 if value == self.data:
                     return
         raise ValueError(self.gettext('Not a valid choice'))
+
+    def _value(self):
+        return self.data

--- a/submit/controllers/util.py
+++ b/submit/controllers/util.py
@@ -38,8 +38,10 @@ def flow_control(prev_page: str, next_page: str, exit_page: str) -> Callable:
 
             def _get_target(page: str) -> str:
                 if submission_id:
-                    return url_for(page, submission_id=submission_id)
-                return url_for(page)
+                    url: str = url_for(page, submission_id=submission_id)
+                else:
+                    url = url_for(page)
+                return url
 
             if action == 'next':
                 headers.update({'Location': _get_target(next_page)})
@@ -80,7 +82,7 @@ def load_submission(submission_id: int) -> events.domain.Submission:
 class OptGroupSelectWidget(Select):
     """Select widget with optgroups."""
 
-    def __call__(self, field: SelectField, **kwargs: Dict) -> HTMLString:
+    def __call__(self, field: SelectField, **kwargs: Any) -> HTMLString:
         """Render the `select` element with `optgroup`s."""
         kwargs.setdefault('id', field.id)
         if self.multiple:
@@ -110,5 +112,6 @@ class OptGroupSelectField(SelectField):
                     return
         raise ValueError(self.gettext('Not a valid choice'))
 
-    def _value(self):
-        return self.data
+    def _value(self) -> str:
+        data: str = self.data
+        return data

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -115,12 +115,16 @@ def classification(submission_id):
         return redirect(headers['Location'], code=code)
 
 
-@blueprint.route('/<int:submission_id>/crosslist', methods=['GET'])
-def crosslist(submission_id):
+@blueprint.route('/<int:submission_id>/cross_list', methods=['GET', 'POST'])
+def cross_list(submission_id):
     """Render step 6, secondary classes."""
+    request_data = MultiDict(request.form.items(multi=True))
+    data, code, headers = controllers.cross_list(request.method, request_data,
+                                                 submission_id)
     rendered = render_template(
-        "submit/secondary_class.html",
-        pagetitle='Choose Secondary Classifications'
+        "submit/cross_list.html",
+        pagetitle='Choose Secondary Classifications',
+        **data
     )
     response = make_response(rendered, status.HTTP_200_OK)
     return response

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -2,8 +2,8 @@
 
 from typing import Optional
 from werkzeug import MultiDict
-from flask import (Blueprint, make_response, redirect, request,
-                   render_template, url_for)
+from flask import Blueprint, make_response, redirect, request, \
+                  render_template, url_for, Response
 from arxiv import status
 from submit import controllers
 
@@ -14,14 +14,14 @@ blueprint = Blueprint('ui', __name__, url_prefix='/')
 
 
 @blueprint.route('/user')
-def user():
+def user() -> Response:
     """Give save and exit button a place to go."""
     return redirect('https://www.arxiv.org/user')
 
 
 @blueprint.route('/create', methods=['GET', 'POST'])
 @blueprint.route('/<int:submission_id>/verify_user', methods=['GET', 'POST'])
-def verify_user(submission_id: Optional[int] = None):
+def verify_user(submission_id: Optional[int] = None) -> Response:
     """Render the submit start page."""
     request_data = MultiDict(request.form.items(multi=True))
     data, code, headers = controllers.verify_user(request.method, request_data,
@@ -40,7 +40,7 @@ def verify_user(submission_id: Optional[int] = None):
 
 
 @blueprint.route('/<int:submission_id>/authorship', methods=['GET', 'POST'])
-def authorship(submission_id):
+def authorship(submission_id: int) -> Response:
     """Render step 2, authorship."""
     request_data = MultiDict(request.form.items(multi=True))
     data, code, headers = controllers.authorship(request.method, request_data,
@@ -59,7 +59,7 @@ def authorship(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/license', methods=['GET', 'POST'])
-def license(submission_id):
+def license(submission_id: int) -> Response:
     """Render step 3, select license."""
     request_data = MultiDict(request.form.items(multi=True))
     data, code, headers = controllers.license(request.method, request_data,
@@ -78,7 +78,7 @@ def license(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/policy', methods=['GET', 'POST'])
-def policy(submission_id):
+def policy(submission_id: int) -> Response:
     """Render step 4, policy agreement."""
     request_data = MultiDict(request.form.items(multi=True))
     data, code, headers = controllers.policy(request.method, request_data,
@@ -98,7 +98,7 @@ def policy(submission_id):
 
 @blueprint.route('/<int:submission_id>/classification',
                  methods=['GET', 'POST'])
-def classification(submission_id):
+def classification(submission_id: int) -> Response:
     """Render step 5, choose classification."""
     request_data = MultiDict(request.form.items(multi=True))
     data, code, headers = controllers.classification(request.method,
@@ -117,22 +117,25 @@ def classification(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/cross_list', methods=['GET', 'POST'])
-def cross_list(submission_id):
+def cross_list(submission_id: int) -> Response:
     """Render step 6, secondary classes."""
     request_data = MultiDict(request.form.items(multi=True))
     data, code, headers = controllers.cross_list(request.method, request_data,
                                                  submission_id)
-    rendered = render_template(
-        "submit/cross_list.html",
-        pagetitle='Choose Secondary Classifications',
-        **data
-    )
-    response = make_response(rendered, status.HTTP_200_OK)
+    if code in [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST]:
+        rendered = render_template(
+            "submit/cross_list.html",
+            pagetitle='Choose Secondary Classifications',
+            **data
+        )
+        response = make_response(rendered, status.HTTP_200_OK)
+    elif code == status.HTTP_303_SEE_OTHER:
+        return redirect(headers['Location'], code=code)
     return response
 
 
 @blueprint.route('/<int:submission_id>/file_upload', methods=['GET'])
-def file_upload(submission_id):
+def file_upload(submission_id: int) -> Response:
     """Render step 7, file add or edit."""
     rendered = render_template(
         "submit/file_upload.html",
@@ -143,7 +146,7 @@ def file_upload(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/file_process', methods=['GET'])
-def file_process(submission_id):
+def file_process(submission_id: int) -> Response:
     """Render step 8, file processing."""
     rendered = render_template(
         "submit/file_process.html",
@@ -154,7 +157,7 @@ def file_process(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/add_metadata', methods=['GET'])
-def add_metadata(submission_id):
+def add_metadata(submission_id: int) -> Response:
     """Render step 9, metadata."""
     rendered = render_template(
         "submit/add_metadata.html",
@@ -165,7 +168,7 @@ def add_metadata(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/add_optional_metadata', methods=['GET'])
-def add_optional_metadata(submission_id):
+def add_optional_metadata(submission_id: int) -> Response:
     """Render step 9, metadata."""
     rendered = render_template(
         "submit/add_optional_metadata.html",
@@ -176,7 +179,7 @@ def add_optional_metadata(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/final_preview', methods=['GET'])
-def final_preview(submission_id):
+def final_preview(submission_id: int) -> Response:
     """Render step 10, preview."""
     rendered = render_template(
         "submit/final_preview.html",
@@ -187,7 +190,7 @@ def final_preview(submission_id):
 
 
 @blueprint.route('/<int:submission_id>/confirm_submit', methods=['GET'])
-def confirm_submit(submission_id):
+def confirm_submit(submission_id: int) -> Response:
     """Render the final confirmation page."""
     rendered = render_template(
         "submit/confirm_submit.html",

--- a/submit/static/css/submit.css
+++ b/submit/static/css/submit.css
@@ -8,7 +8,6 @@
   max-width: 25rem; }
 
 .form-margin {
-    margin-top: 5px;
-    margin-bottom: 5px;
-}
+  margin-top: 0.4em;
+  margin-bottom: 0.4em; }
 /*# sourceMappingURL=submit.css.map */

--- a/submit/static/css/submit.css
+++ b/submit/static/css/submit.css
@@ -7,4 +7,8 @@
 .is-short-field {
   max-width: 25rem; }
 
+.form-margin {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
 /*# sourceMappingURL=submit.css.map */

--- a/submit/static/sass/submit.sass
+++ b/submit/static/sass/submit.sass
@@ -6,3 +6,6 @@
 
 .is-short-field
   max-width: 25rem
+
+.form-margin
+  margin: .4em 0

--- a/submit/templates/submit/classification.html
+++ b/submit/templates/submit/classification.html
@@ -6,27 +6,29 @@
 <h2 class="is-size-4">Choose a primary classification</h2>
 <form method="POST" action="{{ url_for('ui.classification', submission_id=submission_id) }}">
   {% with field = form.category %}
-  <div class="control">
-    {{ field.label }}
-    <div class="select">
-    {% if field.errors %}
-      {{ field(class="is-warning")|safe }}
-    {% else %}
-      {{ field()|safe }}
-    {% endif %}
-    </div>
-    {% if field.errors %}
-      <div class="help is-warning">
-        {% for error in field.errors %}
-            {{ error }}
-        {% endfor %}
+  <div class="field">
+    <div class="control">
+      {{ field.label }}
+      <div class="select">
+      {% if field.errors %}
+        {{ field(class="is-warning")|safe }}
+      {% else %}
+        {{ field()|safe }}
+      {% endif %}
       </div>
-    {% endif %}
-    {% if field.description %}
-    <p class="help has-text-grey">
-      {{ field.description|safe }}
-    </p>
-    {% endif %}
+      {% if field.errors %}
+        <div class="help is-warning">
+          {% for error in field.errors %}
+              {{ error }}
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% if field.description %}
+      <p class="help has-text-grey">
+        {{ field.description|safe }}
+      </p>
+      {% endif %}
+    </div>
   </div>
   {% endwith %}
 

--- a/submit/templates/submit/cross_list.html
+++ b/submit/templates/submit/cross_list.html
@@ -5,44 +5,61 @@
 {% block within_content %}
 <h2 class="is-size-4">Choose cross-list classifications (optional)</h2>
 
-<div class="message is-info is-inline-block">
-  <div class="message-body">
-    <p class="is-subtitle"><strong>Primary: Classification Here</strong></p>
-    <p>Any cross-list classes would go here also.</p>
-  </div>
-</div>
+{% for category, (display, subform) in formset.items() %}
 
-<div class="field">
-  <div class="control">
-    <label class="label">Archive <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <div class="select">
-      <select>
-        <option>archive1</option>
-        <option>archive2</option>
-      </select>
+<form method="POST" class="form form-margin" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
+  {{ subform.operation }}
+  <div class="field has-addons">
+    <div class="control is-expanded">
+      {{ subform.category()|safe }}
+      <input name="display" type="text" class="input" value="{{ display }}" readonly=True />
+    </div>
+    <div class="control">
+      <button class="button is-link is-danger">Remove</button>
     </div>
   </div>
-</div>
-<div class="field">
-  <div class="control">
-    <label class="label">Subject <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <div class="select">
-      <select>
-        <option>subject1</option>
-        <option>subject2</option>
-      </select>
+</form>
+{% endfor %}
+
+<form method="POST" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
+  {{ form.operation }}
+  {% with field = form.category %}
+  <label>Add another cross-list category</label>
+  <div class="field has-addons">
+    <div class="control is-expanded">
+      {% if field.errors %}
+        {{ field(class="input is-warning")|safe }}
+      {% else %}
+        {{ field(class="input")|safe }}
+      {% endif %}
+      {% if field.errors %}
+        <div class="help is-warning">
+          {% for error in field.errors %}
+              {{ error }}
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% if field.description %}
+      <p class="help has-text-grey">
+        {{ field.description|safe }}
+      </p>
+      {% endif %}
+    </div>
+    <div class="control">
+      <button class="button is-link">Add</button>
     </div>
   </div>
-</div>
-
-<div class="field">
-  <div class="control">
-    <button class="button">
-      <span class="icon"><i class="fa fa-plus"></i></span>
-      <span>Add Another Classification</span>
-    </button>
+    {% endwith %}
+  <div class="field">
+    <div class="control">
+      <button class="button">
+        <span class="icon"><i class="fa fa-plus"></i></span>
+        <span>Add Another Classification</span>
+      </button>
+    </div>
   </div>
-</div>
+</form>
+
 
 <div class="message is-info is-inline-block submit-nav">
   <div class="message-body">

--- a/submit/templates/submit/cross_list.html
+++ b/submit/templates/submit/cross_list.html
@@ -5,14 +5,17 @@
 {% block within_content %}
 <h2 class="is-size-4">Choose cross-list classifications (optional)</h2>
 
+<div class="message is-info is-inline-block submit-nav">
+  <div class="message-body">
+
 {% for category, (display, subform) in formset.items() %}
 
 <form method="POST" class="form form-margin" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
   {{ subform.operation }}
   <div class="field has-addons">
-    <div class="control is-expanded">
+    <div class="control">
       {{ subform.category()|safe }}
-      <input name="display" type="text" class="input" value="{{ display }}" readonly=True />
+      <span class=""></span>{{ subform.category.data }} <span class="input">{{ display }}</span>
     </div>
     <div class="control">
       <button class="button is-link is-danger">Remove</button>
@@ -20,18 +23,22 @@
   </div>
 </form>
 {% endfor %}
+  </div>
+</div>
 
 <form method="POST" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
   {{ form.operation }}
   {% with field = form.category %}
   <label>Add another cross-list category</label>
   <div class="field has-addons">
-    <div class="control is-expanded">
+    <div class="control">
+      <div class="select">
       {% if field.errors %}
-        {{ field(class="input is-warning")|safe }}
+        {{ field(class="is-warning")|safe }}
       {% else %}
-        {{ field(class="input")|safe }}
+        {{ field()|safe }}
       {% endif %}
+      </div>
       {% if field.errors %}
         <div class="help is-warning">
           {% for error in field.errors %}
@@ -50,23 +57,20 @@
     </div>
   </div>
     {% endwith %}
-  <div class="field">
-    <div class="control">
-      <button class="button">
-        <span class="icon"><i class="fa fa-plus"></i></span>
-        <span>Add Another Classification</span>
-      </button>
+
+    <div class="message is-info is-inline-block submit-nav">
+      <div class="message-body">
+        <p>
+          <span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>
+          Adding more than three cross-list classifications will result in a delay
+          in the acceptance of your submission.
+        </p>
+      </div>
     </div>
-  </div>
+
+    {{ submit_macros.submit_nav() }}
 </form>
 
 
-<div class="message is-info is-inline-block submit-nav">
-  <div class="message-body">
-    <p><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>
-    More than three cross-list classifications will result in a delay in the acceptance of your submission.</p>
-  </div>
-</div>
 
-{{ submit_macros.submit_nav() }}
 {% endblock within_content %}

--- a/submit/templates/submit/cross_list.html
+++ b/submit/templates/submit/cross_list.html
@@ -5,24 +5,23 @@
 {% block within_content %}
 <h2 class="is-size-4">Choose cross-list classifications (optional)</h2>
 
+
 <div class="message is-info is-inline-block submit-nav">
   <div class="message-body">
+    <p>
+      <span class="tag is-small is-link">{{ primary.id }}</span> {{ primary.name }}
+    </p>
 
-{% for category, (display, subform) in formset.items() %}
+    {% for category, (display, subform) in formset.items() %}
 
-<form method="POST" class="form form-margin" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
-  {{ subform.operation }}
-  <div class="field has-addons">
-    <div class="control">
+    <form method="POST" class="form form-margin" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
+      {{ subform.operation }}
       {{ subform.category()|safe }}
-      <span class=""></span>{{ subform.category.data }} <span class="input">{{ display }}</span>
-    </div>
-    <div class="control">
-      <button class="button is-link is-danger">Remove</button>
-    </div>
-  </div>
-</form>
-{% endfor %}
+      <span class="tag is-small is-dark">{{ subform.category.data }}</span> <span>{{ display }}</span>
+
+      <button class="button is-link is-danger is-small">&#xf1f8;</button>
+    </form>
+    {% endfor %}
   </div>
 </div>
 

--- a/submit/templates/submit/cross_list.html
+++ b/submit/templates/submit/cross_list.html
@@ -8,14 +8,14 @@
 
 <div class="message is-info is-inline-block submit-nav">
   <div class="message-body">
-    <p class="has-text-weight-bold">
+    <p class="has-text-weight-bold" style="margin-bottom: .5em">
       <span class="tag is-link">{{ primary.id }}</span> {{ primary.name }}
     </p>
 
     {% for category, (display, subform) in formset.items() %}
 
     <form method="POST" class="form form-margin" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
-      <p style="margin-bottom: .5em">
+      <p>
         {{ subform.operation }}
         {{ subform.category()|safe }}
           <span class="tag" style="border: 1px solid #999;">{{ subform.category.data }}</span> <span>{{ display }}</span>

--- a/submit/templates/submit/cross_list.html
+++ b/submit/templates/submit/cross_list.html
@@ -8,27 +8,31 @@
 
 <div class="message is-info is-inline-block submit-nav">
   <div class="message-body">
-    <p>
-      <span class="tag is-small is-link">{{ primary.id }}</span> {{ primary.name }}
+    <p class="has-text-weight-bold">
+      <span class="tag is-link">{{ primary.id }}</span> {{ primary.name }}
     </p>
 
     {% for category, (display, subform) in formset.items() %}
 
     <form method="POST" class="form form-margin" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
-      {{ subform.operation }}
-      {{ subform.category()|safe }}
-      <span class="tag is-small is-dark">{{ subform.category.data }}</span> <span>{{ display }}</span>
-
-      <button class="button is-link is-danger is-small">&#xf1f8;</button>
+      <p style="margin-bottom: .5em">
+        {{ subform.operation }}
+        {{ subform.category()|safe }}
+          <span class="tag" style="border: 1px solid #999;">{{ subform.category.data }}</span> <span>{{ display }}</span>
+        <button class="button is-outlined is-link is-small" style="border: 0" aria-label="remove">
+          <span class="icon"><i class="fa fa-trash"></i>
+        </button>
+      </p>
     </form>
     {% endfor %}
+
   </div>
 </div>
 
 <form method="POST" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
   {{ form.operation }}
   {% with field = form.category %}
-  <label>Add another cross-list category</label>
+  <label>Add a cross-list category</label>
   <div class="field has-addons">
     <div class="control">
       <div class="select">

--- a/submit/templates/submit/submit_macros.html
+++ b/submit/templates/submit/submit_macros.html
@@ -18,7 +18,7 @@
   <span><a class="button" title="Choose license" href="{% if submission_id %}{{ url_for('ui.license', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">3</a></span>
   <span><a class="button" title="Acknowledge policy" href="{% if submission_id %}{{ url_for('ui.policy', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">4</a></span>
   <span><a class="button" title="Primary class" href="{% if submission_id %}{{ url_for('ui.classification', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">5</a></span>
-  <span><a class="button" title="Secondary class" href="{% if submission_id %}{{ url_for('ui.cross_list', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">6</a></span>
+  <span><a class="button" title="Cross-list" href="{% if submission_id %}{{ url_for('ui.cross_list', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">6</a></span>
   <span><a class="button" title="File upload" href="{% if submission_id %}{{ url_for('ui.file_upload', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">7</a></span>
   <span><a class="button" title="File process" href="{% if submission_id %}{{ url_for('ui.file_process', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">8</a></span>
   <span><a class="button" title="Add metadata" href="{% if submission_id %}{{ url_for('ui.add_metadata', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">9</a></span>

--- a/submit/templates/submit/submit_macros.html
+++ b/submit/templates/submit/submit_macros.html
@@ -18,7 +18,7 @@
   <span><a class="button" title="Choose license" href="{% if submission_id %}{{ url_for('ui.license', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">3</a></span>
   <span><a class="button" title="Acknowledge policy" href="{% if submission_id %}{{ url_for('ui.policy', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">4</a></span>
   <span><a class="button" title="Primary class" href="{% if submission_id %}{{ url_for('ui.classification', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">5</a></span>
-  <span><a class="button" title="Secondary class" href="{% if submission_id %}{{ url_for('ui.crosslist', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">6</a></span>
+  <span><a class="button" title="Secondary class" href="{% if submission_id %}{{ url_for('ui.cross_list', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">6</a></span>
   <span><a class="button" title="File upload" href="{% if submission_id %}{{ url_for('ui.file_upload', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">7</a></span>
   <span><a class="button" title="File process" href="{% if submission_id %}{{ url_for('ui.file_process', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">8</a></span>
   <span><a class="button" title="Add metadata" href="{% if submission_id %}{{ url_for('ui.add_metadata', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">9</a></span>

--- a/submit/tests/__init__.py
+++ b/submit/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the application as a whole."""


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3451594/41663255-f9740fea-7470-11e8-99a6-1961077d9124.png)

This adds cross-list functionality to the submission UI. Things that this PR does now:
- Allows the user to add and remove cross-list categories. Note that:
  - If a primary is selected, it will not show up in the drop-down for secondaries; 
  - A given category cannot be added twice; 
  - Selected secondaries do not appear as options for primary (if the user goes back).
- Catches up on type annotations and some minor docstyle issues.

Things that this feature does not do:
- Limit option to endorsed/preferred categories (out of scope)
- Address accessibility issue around optgroup font weight (let's address with filtering)

**Note**: In this implementation, if the user has selected a category but has **not** clicked the "add" button, I am not saving the result on previous/next. This seemed the most intuitive to me, but please feel free to resist that. This is a complex feature in some ways; let's consider all options.

@eawoods I'm looking to you primarily for feedback on expected UX/functionality and layout/appearance.

@DavidLFielding Adding you for an extra set of eyes, if you get a chance. 

I'd like to merge this by noon tomorrow (Thursday, 21 June), so that we can keep rolling.