### PR TITLE
ARXIVNG-878 core and optional metadata

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,9 @@ WTForms = "==2.1"
 PyYAML = "*"
 pytz = "*"
 SQLAlchemy = "*"
-arxiv-submission-events = "==0.2.4"
+"3a3786f" = {path = "./../arxiv-submission-core/core"}
+bleach = "*"
+arxiv-submission-events = "==0.3.1"
 
 [dev-packages]
 "nose2" = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ WTForms = "==2.1"
 PyYAML = "*"
 pytz = "*"
 SQLAlchemy = "*"
-arxiv-submission-events = "==0.2.3"
+arxiv-submission-events = "==0.2.4"
 
 [dev-packages]
 "nose2" = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ WTForms = "==2.1"
 PyYAML = "*"
 pytz = "*"
 SQLAlchemy = "*"
-"3a3786f" = {path = "./../arxiv-submission-core/core"}
 bleach = "*"
 arxiv-submission-events = "==0.3.1"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6e01f5f7dc7f88216cd9c12a92fa08b610b662e92d0560798d161b83ef9457e9"
+            "sha256": "148f5e47204243e2bf80cff06214670ba860891f3dc423194097608a9f26bffb"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,9 @@
         ]
     },
     "default": {
+        "3a3786f": {
+            "path": "./../arxiv-submission-core/core"
+        },
         "arxiv-base": {
             "hashes": [
                 "sha256:e386f771296d2971d0435640a732dc3c77c4f7856ddabfe0daba9e3bafbd6dfb"
@@ -23,10 +26,18 @@
         },
         "arxiv-submission-events": {
             "hashes": [
-                "sha256:6fa5c24916e53db8a2394b5545790cfaad6058688ceff8c5eb29d810c25c7e9a"
+                "sha256:1262e74098cdaa81b512540ce4ee8babaaf6d7d585b787b2e9cce90fa1a5a50d"
             ],
             "index": "pypi",
-            "version": "==0.2.4"
+            "version": "==0.3.1"
+        },
+        "bleach": {
+            "hashes": [
+                "sha256:b8fa79e91f96c2c2cd9fd1f9eda906efb1b88b483048978ba62fef680e962b34",
+                "sha256:eb7386f632349d10d9ce9d4a838b134d4731571851149f9cc2c05a9a837a9a44"
+            ],
+            "index": "pypi",
+            "version": "==2.1.3"
         },
         "click": {
             "hashes": [
@@ -50,6 +61,13 @@
             ],
             "index": "pypi",
             "version": "==1.0.2"
+        },
+        "html5lib": {
+            "hashes": [
+                "sha256:20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3",
+                "sha256:66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736"
+            ],
+            "version": "==1.0.1"
         },
         "itsdangerous": {
             "hashes": [
@@ -106,6 +124,13 @@
             "index": "pypi",
             "version": "==3.12"
         },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
         "sqlalchemy": {
             "hashes": [
                 "sha256:2d5f08f714a886a1382c18be501e614bce50d362384dc089474019ce0768151c"
@@ -119,6 +144,13 @@
             ],
             "index": "pypi",
             "version": "==2.0.17"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         },
         "werkzeug": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "148f5e47204243e2bf80cff06214670ba860891f3dc423194097608a9f26bffb"
+            "sha256": "4ca2db4e8ae2ad923a75e2bedf50562c6dbc12549158c07a2aba1a4312792d2d"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,9 +14,6 @@
         ]
     },
     "default": {
-        "3a3786f": {
-            "path": "./../arxiv-submission-core/core"
-        },
         "arxiv-base": {
             "hashes": [
                 "sha256:e386f771296d2971d0435640a732dc3c77c4f7856ddabfe0daba9e3bafbd6dfb"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "701c9d6f390e33303dd02024dfef6bb9bfe47faea04ec1357e3cd2af37e5ae59"
+            "sha256": "6e01f5f7dc7f88216cd9c12a92fa08b610b662e92d0560798d161b83ef9457e9"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,10 +23,10 @@
         },
         "arxiv-submission-events": {
             "hashes": [
-                "sha256:fb626773d72e3f1cba38f0757ee98a8b436516c524335a1b2c8b67411a177e4b"
+                "sha256:6fa5c24916e53db8a2394b5545790cfaad6058688ceff8c5eb29d810c25c7e9a"
             ],
             "index": "pypi",
-            "version": "==0.2.3"
+            "version": "==0.2.4"
         },
         "click": {
             "hashes": [

--- a/submit/controllers/__init__.py
+++ b/submit/controllers/__init__.py
@@ -5,6 +5,7 @@ from .authorship import authorship
 from .license import license
 from .policy import policy
 from .classification import classification, cross_list
+from .metadata import metadata, optional
 
 __all__ = ('verify_user', 'authorship', 'license', 'policy', 'classification',
-           'cross_list')
+           'cross_list', 'metadata', 'optional')

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -25,9 +25,9 @@ Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
 class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
     """Handles core metadata fields on a submission."""
 
-    title = TextField('Title', validators=[validators.DataRequired()])
+    title = TextField('*Title', validators=[validators.DataRequired()])
     authors_display = TextAreaField(
-        'Authors',
+        '*Authors',
         validators=[validators.DataRequired()],
         description=(
             "use <code>Forename Surname</code> or <code>I. "
@@ -35,7 +35,7 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
             "a comma or 'and'."
         )
     )
-    abstract = TextAreaField('Abstract',
+    abstract = TextAreaField('*Abstract',
                              validators=[validators.DataRequired()],
                              description='Limit of 1920 characters')
     comments = TextField('Comments',

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -47,46 +47,26 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
         """Validate title input using core events."""
         if field.data == form.submission.metadata.title:     # Nothing to do.
             return
-        ev = events.SetTitle(creator=form.creator, title=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
+        form._validate_with_event(events.SetTitle, title=field.data)
 
     def validate_abstract(form: Form, field: Field) -> None:
         """Validate abstract input using core events."""
         if field.data == form.submission.metadata.abstract:    # Nothing to do.
             return
-        ev = events.SetAbstract(creator=form.creator, abstract=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
+        form._validate_with_event(events.SetAbstract, abstract=field.data)
 
     def validate_comments(form: Form, field: Field) -> None:
         """Validate comments input using core events."""
         if field.data == form.submission.metadata.comments:    # Nothing to do.
             return
-        ev = events.SetComments(creator=form.creator, comments=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
+        form._validate_with_event(events.SetComments, comments=field.data)
 
     def validate_authors_display(form: Form, field: Field) -> None:
         """Validate authors input using core events."""
         if field.data == form.submission.metadata.authors:     # Nothing to do.
             return
-        ev = events.UpdateAuthors(creator=form.creator,
+        form._validate_with_event(events.UpdateAuthors,
                                   authors_display=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
 
 
 class OptionalMetadataForm(Form, FieldMixin, SubmissionMixin):
@@ -120,60 +100,35 @@ class OptionalMetadataForm(Form, FieldMixin, SubmissionMixin):
         """Validate DOI input using core events."""
         if field.data == form.submission.metadata.doi:     # Nothing to do.
             return
-        ev = events.SetDOI(creator=form.creator, doi=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
+        form._validate_with_event(events.SetDOI, doi=field.data)
 
     def validate_journal_ref(form: Form, field: Field) -> None:
         """Validate journal reference input using core events."""
         if field.data == form.submission.metadata.journal_ref:
             return
-        ev = events.SetJournalReference(creator=form.creator,
-                                        journal_ref=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
+        form._validate_with_event(events.SetJournalReference,
+                                  journal_ref=field.data)
 
     def validate_report_num(form: Form, field: Field) -> None:
         """Validate report number input using core events."""
         if field.data == form.submission.metadata.report_num:
             return
-        ev = events.SetReportNumber(creator=form.creator,
-                                    report_num=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
+        form._validate_with_event(events.SetReportNumber,
+                                  report_num=field.data)
 
     def validate_acm_class(form: Form, field: Field) -> None:
         """Validate ACM classification input using core events."""
         if field.data == form.submission.metadata.acm_class:
             return
-        ev = events.SetACMClassification(creator=form.creator,
-                                         acm_class=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
+        form._validate_with_event(events.SetACMClassification,
+                                  acm_class=field.data)
 
     def validate_msc_class(form: Form, field: Field) -> None:
         """Validate MSC classification input using core events."""
         if field.data == form.submission.metadata.msc_class:
             return
-        ev = events.SetMSCClassification(creator=form.creator,
-                                         msc_class=field.data)
-        form._add_event(ev)
-        try:
-            ev.validate(form.submission)
-        except events.InvalidEvent as e:
-            raise validators.ValidationError(e.message) from e
+        form._validate_with_event(events.SetACMClassification,
+                                  msc_class=field.data)
 
 
 def _data_from_submission(params: MultiDict, submission: events.Submission,

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -28,6 +28,7 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
     title = TextField('Title', validators=[validators.DataRequired()])
     authors_display = TextField(
         'Authors',
+        validators=[validators.DataRequired()],
         description=(
             "use <code>Forename Surname</code> or <code>I. "
             "Surname</code>; separate individual authors with "
@@ -35,8 +36,10 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
         )
     )
     abstract = TextAreaField('Abstract',
+                             validators=[validators.DataRequired()],
                              description='Limit of 1920 characters')
     comments = TextField('Comments',
+                         default='',
                          validators=[validators.optional()],
                          description=(
                             "Supplemental information such as number of pages "
@@ -61,12 +64,12 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
         """Validate comments input using core events."""
         if field.data == form.submission.metadata.comments:    # Nothing to do.
             return
-        if field.data:
+        if field.data is not None:
             form._validate_event(events.SetComments, comments=field.data)
 
     def validate_authors_display(form: Form, field: Field) -> None:
         """Validate authors input using core events."""
-        if field.data == form.submission.metadata.authors:     # Nothing to do.
+        if field.data == form.submission.metadata.authors_display:
             return
         if field.data:
             form._validate_event(events.UpdateAuthors,
@@ -136,7 +139,7 @@ class OptionalMetadataForm(Form, FieldMixin, SubmissionMixin):
         if field.data == form.submission.metadata.msc_class:
             return
         if field.data:
-            form._validate_event(events.SetACMClassification,
+            form._validate_event(events.SetMSCClassification,
                                  msc_class=field.data)
 
 

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -47,25 +47,25 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
         """Validate title input using core events."""
         if field.data == form.submission.metadata.title:     # Nothing to do.
             return
-        form._validate_with_event(events.SetTitle, title=field.data)
+        form._validate_event(events.SetTitle, title=field.data)
 
     def validate_abstract(form: Form, field: Field) -> None:
         """Validate abstract input using core events."""
         if field.data == form.submission.metadata.abstract:    # Nothing to do.
             return
-        form._validate_with_event(events.SetAbstract, abstract=field.data)
+        form._validate_event(events.SetAbstract, abstract=field.data)
 
     def validate_comments(form: Form, field: Field) -> None:
         """Validate comments input using core events."""
         if field.data == form.submission.metadata.comments:    # Nothing to do.
             return
-        form._validate_with_event(events.SetComments, comments=field.data)
+        form._validate_event(events.SetComments, comments=field.data)
 
     def validate_authors_display(form: Form, field: Field) -> None:
         """Validate authors input using core events."""
         if field.data == form.submission.metadata.authors:     # Nothing to do.
             return
-        form._validate_with_event(events.UpdateAuthors,
+        form._validate_event(events.UpdateAuthors,
                                   authors_display=field.data)
 
 
@@ -100,34 +100,34 @@ class OptionalMetadataForm(Form, FieldMixin, SubmissionMixin):
         """Validate DOI input using core events."""
         if field.data == form.submission.metadata.doi:     # Nothing to do.
             return
-        form._validate_with_event(events.SetDOI, doi=field.data)
+        form._validate_event(events.SetDOI, doi=field.data)
 
     def validate_journal_ref(form: Form, field: Field) -> None:
         """Validate journal reference input using core events."""
         if field.data == form.submission.metadata.journal_ref:
             return
-        form._validate_with_event(events.SetJournalReference,
+        form._validate_event(events.SetJournalReference,
                                   journal_ref=field.data)
 
     def validate_report_num(form: Form, field: Field) -> None:
         """Validate report number input using core events."""
         if field.data == form.submission.metadata.report_num:
             return
-        form._validate_with_event(events.SetReportNumber,
+        form._validate_event(events.SetReportNumber,
                                   report_num=field.data)
 
     def validate_acm_class(form: Form, field: Field) -> None:
         """Validate ACM classification input using core events."""
         if field.data == form.submission.metadata.acm_class:
             return
-        form._validate_with_event(events.SetACMClassification,
+        form._validate_event(events.SetACMClassification,
                                   acm_class=field.data)
 
     def validate_msc_class(form: Form, field: Field) -> None:
         """Validate MSC classification input using core events."""
         if field.data == form.submission.metadata.msc_class:
             return
-        form._validate_with_event(events.SetACMClassification,
+        form._validate_event(events.SetACMClassification,
                                   msc_class=field.data)
 
 

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -26,7 +26,7 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
     """Handles core metadata fields on a submission."""
 
     title = TextField('Title', validators=[validators.DataRequired()])
-    authors_display = TextField(
+    authors_display = TextAreaField(
         'Authors',
         validators=[validators.DataRequired()],
         description=(

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -1,0 +1,226 @@
+"""Provides a controller for updating metadata on a submission."""
+
+from typing import Tuple, Dict, Any
+
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError
+from flask import url_for
+from wtforms import Form
+from wtforms.fields import TextField, TextAreaField, Field
+from wtforms.fields.core import UnboundField
+from wtforms import validators
+
+from arxiv import status
+from arxiv.base import logging
+import events
+
+from .util import flow_control, load_submission
+
+# from arxiv-submission-core.events.event import VerifyContactInformation
+
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
+
+Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
+
+
+class FieldMixin:
+    """Provide a convenience classmethod for field names."""
+
+    @classmethod
+    def fields(cls):
+        """Convenience accessor for form field names."""
+        return [key for key in dir(cls)
+                if isinstance(getattr(cls, key), UnboundField)]
+
+
+class CoreMetadataForm(Form, FieldMixin):
+    """Handles core metadata fields on a submission."""
+
+    title = TextField('Title', validators=[validators.Length(min=6, max=255)])
+    authors_display = TextField(
+        'Authors',
+        validators=[validators.Length(min=6)],
+        description=(
+            "use <code>Forename Surname</code> or <code>I. "
+            "Surname</code>; separate individual authors with "
+            "a comma or 'and'."
+        )
+    )
+    abstract = TextAreaField('Abstract',
+                             validators=[validators.Length(min=6, max=1920)],
+                             description='Limit of 1920 characters')
+    comments = TextField('Comments',
+                         validators=[validators.optional()],
+                         description=(
+                            "Supplemental information such as number of pages "
+                            "or figures, conference information."
+                         ))
+
+
+class OptionalMetadataForm(Form, FieldMixin):
+    """Handles optional metadata fields on a submission."""
+
+    doi = TextField('DOI',
+                    validators=[validators.optional()],
+                    description="Full DOI of the version of record.")
+    journal_ref = TextField('Journal reference',
+                            validators=[validators.optional()],
+                            description=(
+                                "See <a href='https://arxiv.org/help/jref'>"
+                                "the arXiv help pages</a> for details."
+                            ))
+    report_num = TextField('Report number',
+                           validators=[validators.optional()],
+                           description=(
+                               "See <a href='https://arxiv.org/help/jref'>"
+                               "the arXiv help pages</a> for details."
+                           ))
+    acm_class = TextField('ACM classification',
+                          validators=[validators.optional()],
+                          description="example: F.2.2; I.2.7")
+
+    msc_class = TextField('MSC classification',
+                          validators=[validators.optional()],
+                          description=("example: 14J60 (Primary), 14F05, "
+                                       "14J26 (Secondary)"))
+
+
+def _data_from_submission(params: MultiDict, submission: events.Submission,
+                          form_class: type) -> MultiDict:
+    if not submission.metadata:
+        return params
+    for field in form_class.fields():
+        params[field] = getattr(submission.metadata, field, '')
+    return params
+
+
+def _get_fields_to_update(form: CoreMetadataForm,
+                          submission: events.Submission) -> dict:
+    """
+    Determine which fields to update on the submission.
+
+    There is nothing to do if a value has not changed.
+    """
+    to_update = {}
+    for field in form.fields():
+        form_value = getattr(getattr(form, field), 'data', '')
+        if form_value != getattr(submission.metadata, field):
+            to_update[field] = form_value
+    return to_update
+
+
+@flow_control('ui.file_process', 'ui.add_optional_metadata', 'ui.user')
+def metadata(method: str, params: MultiDict, submission_id: int) -> Response:
+    """Update metadata on the submission."""
+    logger.debug(f'method: {method}, submission: {submission_id}. {params}')
+
+    # TODO: Create a concrete User from cookie info.
+    submitter = events.domain.User(1, email='ian413@cornell.edu',
+                                   forename='Ima', surname='Nauthor')
+
+    # Will raise NotFound if there is no such submission.
+    submission = load_submission(submission_id)
+    # The form should be prepopulated based on the current state of the
+    # submission.
+    if method == 'GET':
+        params = _data_from_submission(params, submission, CoreMetadataForm)
+
+    form = CoreMetadataForm(params)
+    response_data = {'submission_id': submission_id, 'form': form}
+
+    if method == 'POST':
+        if not form.validate():
+            logger.debug('Invalid form data; return bad request')
+            return response_data, status.HTTP_400_BAD_REQUEST, {}
+
+        logger.debug('Form is valid, with data: %s', str(form.data))
+
+        # We only want to apply an UpdateMetadata if the metadata has
+        # actually changed.
+        to_update = _get_fields_to_update(form, submission)
+        if to_update:   # Metadata has changed.
+            try:
+                # Create UpdateMetadata event
+                submission, stack = events.save(  # pylint: disable=W0612
+                    events.UpdateMetadata(
+                        creator=submitter,
+                        metadata=list(to_update.items())
+                    ),
+                    submission_id=submission_id
+                )
+            except events.exceptions.InvalidStack as e:
+                logger.error('Could not update metadata: %s', str(e))
+                form.errors     # Causes the form to initialize errors.
+                form._errors['events'] = [ie.message for ie
+                                          in e.event_exceptions]
+                logger.debug('InvalidStack; return bad request')
+                return response_data, status.HTTP_400_BAD_REQUEST, {}
+            except events.exceptions.SaveError as e:
+                logger.error('Could not save metadata event')
+                raise InternalServerError(
+                    'There was a problem saving this operation'
+                ) from e
+    if params.get('action') in ['previous', 'save_exit', 'next']:
+        logger.debug('Redirect to %s', params.get('action'))
+        return response_data, status.HTTP_303_SEE_OTHER, {}
+    logger.debug('Nothing to do, return 200')
+    return response_data, status.HTTP_200_OK, {}
+
+
+@flow_control('ui.add_metadata', 'ui.confirm_submit', 'ui.user')
+def optional(method: str, params: MultiDict, submission_id: int) -> Response:
+    """Update optional metadata on the submission."""
+    logger.debug(f'method: {method}, submission: {submission_id}. {params}')
+
+    # TODO: Create a concrete User from cookie info.
+    submitter = events.domain.User(1, email='ian413@cornell.edu',
+                                   forename='Ima', surname='Nauthor')
+
+    # Will raise NotFound if there is no such submission.
+    submission = load_submission(submission_id)
+    # The form should be prepopulated based on the current state of the
+    # submission.
+    if method == 'GET':
+        params = _data_from_submission(params, submission,
+                                       OptionalMetadataForm)
+
+    form = OptionalMetadataForm(params)
+    response_data = {'submission_id': submission_id, 'form': form}
+
+    if method == 'POST':
+        if not form.validate():
+            logger.debug('Invalid form data; return bad request')
+            return response_data, status.HTTP_400_BAD_REQUEST, {}
+
+        logger.debug('Form is valid, with data: %s', str(form.data))
+
+        # We only want to apply an UpdateMetadata if the metadata has
+        # actually changed.
+        to_update = _get_fields_to_update(form, submission)
+        if to_update:   # Metadata has changed.
+            try:
+                # Create UpdateMetadata event
+                submission, stack = events.save(  # pylint: disable=W0612
+                    events.UpdateMetadata(
+                        creator=submitter,
+                        metadata=list(to_update.items())
+                    ),
+                    submission_id=submission_id
+                )
+            except events.exceptions.InvalidStack as e:
+                logger.error('Could not update metadata: %s', str(e))
+                form.errors     # Causes the form to initialize errors.
+                form._errors['events'] = [ie.message for ie
+                                          in e.event_exceptions]
+                logger.debug('InvalidStack; return bad request')
+                return response_data, status.HTTP_400_BAD_REQUEST, {}
+            except events.exceptions.SaveError as e:
+                logger.error('Could not save metadata event')
+                raise InternalServerError(
+                    'There was a problem saving this operation'
+                ) from e
+    if params.get('action') in ['previous', 'save_exit', 'next']:
+        logger.debug('Redirect to %s', params.get('action'))
+        return response_data, status.HTTP_303_SEE_OTHER, {}
+    logger.debug('Nothing to do, return 200')
+    return response_data, status.HTTP_200_OK, {}

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -25,7 +25,7 @@ Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
 class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
     """Handles core metadata fields on a submission."""
 
-    title = TextField('Title')
+    title = TextField('Title', validators=[validators.DataRequired()])
     authors_display = TextField(
         'Authors',
         description=(
@@ -47,26 +47,30 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
         """Validate title input using core events."""
         if field.data == form.submission.metadata.title:     # Nothing to do.
             return
-        form._validate_event(events.SetTitle, title=field.data)
+        if field.data:
+            form._validate_event(events.SetTitle, title=field.data)
 
     def validate_abstract(form: Form, field: Field) -> None:
         """Validate abstract input using core events."""
         if field.data == form.submission.metadata.abstract:    # Nothing to do.
             return
-        form._validate_event(events.SetAbstract, abstract=field.data)
+        if field.data:
+            form._validate_event(events.SetAbstract, abstract=field.data)
 
     def validate_comments(form: Form, field: Field) -> None:
         """Validate comments input using core events."""
         if field.data == form.submission.metadata.comments:    # Nothing to do.
             return
-        form._validate_event(events.SetComments, comments=field.data)
+        if field.data:
+            form._validate_event(events.SetComments, comments=field.data)
 
     def validate_authors_display(form: Form, field: Field) -> None:
         """Validate authors input using core events."""
         if field.data == form.submission.metadata.authors:     # Nothing to do.
             return
-        form._validate_event(events.UpdateAuthors,
-                                  authors_display=field.data)
+        if field.data:
+            form._validate_event(events.UpdateAuthors,
+                                 authors_display=field.data)
 
 
 class OptionalMetadataForm(Form, FieldMixin, SubmissionMixin):
@@ -100,35 +104,40 @@ class OptionalMetadataForm(Form, FieldMixin, SubmissionMixin):
         """Validate DOI input using core events."""
         if field.data == form.submission.metadata.doi:     # Nothing to do.
             return
-        form._validate_event(events.SetDOI, doi=field.data)
+        if field.data:
+            form._validate_event(events.SetDOI, doi=field.data)
 
     def validate_journal_ref(form: Form, field: Field) -> None:
         """Validate journal reference input using core events."""
         if field.data == form.submission.metadata.journal_ref:
             return
-        form._validate_event(events.SetJournalReference,
-                                  journal_ref=field.data)
+        if field.data:
+            form._validate_event(events.SetJournalReference,
+                                 journal_ref=field.data)
 
     def validate_report_num(form: Form, field: Field) -> None:
         """Validate report number input using core events."""
         if field.data == form.submission.metadata.report_num:
             return
-        form._validate_event(events.SetReportNumber,
-                                  report_num=field.data)
+        if field.data:
+            form._validate_event(events.SetReportNumber,
+                                 report_num=field.data)
 
     def validate_acm_class(form: Form, field: Field) -> None:
         """Validate ACM classification input using core events."""
         if field.data == form.submission.metadata.acm_class:
             return
-        form._validate_event(events.SetACMClassification,
-                                  acm_class=field.data)
+        if field.data:
+            form._validate_event(events.SetACMClassification,
+                                 acm_class=field.data)
 
     def validate_msc_class(form: Form, field: Field) -> None:
         """Validate MSC classification input using core events."""
         if field.data == form.submission.metadata.msc_class:
             return
-        form._validate_event(events.SetACMClassification,
-                                  msc_class=field.data)
+        if field.data:
+            form._validate_event(events.SetACMClassification,
+                                 msc_class=field.data)
 
 
 def _data_from_submission(params: MultiDict, submission: events.Submission,

--- a/submit/controllers/tests/test_metadata.py
+++ b/submit/controllers/tests/test_metadata.py
@@ -2,6 +2,7 @@
 
 from unittest import TestCase, mock
 from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError
 from wtforms import Form
 from arxiv import status
 from submit.controllers import metadata, optional
@@ -38,6 +39,59 @@ class TestOptional(TestCase):
 
     @mock.patch('events.save')
     @mock.patch('events.load')
+    def test_invalid_stack_is_raised(self, mock_load, mock_save):
+        """POST request results in an InvalidStack exception."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock()
+        )
+        mock_load.return_value = (mock_submission, [])
+
+        def raise_invalid_stack(*args, **kwargs):
+            raise events.InvalidStack([])
+
+        mock_save.side_effect = raise_invalid_stack
+        request_data = MultiDict({
+            'doi': '10.0001/123456',
+            'journal_ref': 'foo journal 10 2010: 12-345',
+            'report_num': 'foo report 12',
+            'acm_class': 'F.2.2; I.2.7',
+            'msc_class': '14J26'
+        })
+        data, code, headers = optional('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_save_error_is_raised(self, mock_load, mock_save):
+        """POST request results in an SaveError exception."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock()
+        )
+        mock_load.return_value = (mock_submission, [])
+
+        def raise_save_error(*args, **kwargs):
+            raise events.SaveError('nope')
+
+        mock_save.side_effect = raise_save_error
+        request_data = MultiDict({
+            'doi': '10.0001/123456',
+            'journal_ref': 'foo journal 10 2010: 12-345',
+            'report_num': 'foo report 12',
+            'acm_class': 'F.2.2; I.2.7',
+            'msc_class': '14J26'
+        })
+        with self.assertRaises(InternalServerError):
+            optional('POST', request_data, submission_id)
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
     def test_post_request_with_required_data(self, mock_load, mock_save):
         """POST request with all fields."""
         submission_id = 2
@@ -67,6 +121,70 @@ class TestOptional(TestCase):
                       "Sets ACM classification")
         self.assertIn(events.SetMSCClassification, event_types,
                       "Sets MSC classification")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_with_unchanged_data(self, mock_load, mock_save):
+        """POST request with valid but unchanged data."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock(**{
+                'doi': '10.0001/123456',
+                'journal_ref': 'foo journal 10 2010: 12-345',
+                'report_num': 'foo report 12',
+                'acm_class': 'F.2.2; I.2.7',
+                'msc_class': '14J26'
+            })
+        )
+        mock_load.return_value = (mock_submission, [])
+        mock_save.return_value = (mock_submission, [])
+        request_data = MultiDict({
+            'doi': '10.0001/123456',
+            'journal_ref': 'foo journal 10 2010: 12-345',
+            'report_num': 'foo report 12',
+            'acm_class': 'F.2.2; I.2.7',
+            'msc_class': '14J26'
+        })
+        data, code, headers = optional('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(mock_save.call_count, 0, "No events are generated")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_with_some_changes(self, mock_load, mock_save):
+        """POST request with only some changed data."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock(**{
+                'doi': '10.0001/123456',
+                'journal_ref': 'foo journal 10 2010: 12-345',
+                'report_num': 'foo report 12',
+                'acm_class': 'F.2.2; I.2.7',
+                'msc_class': '14J26'
+            })
+        )
+        mock_load.return_value = (mock_submission, [])
+        mock_save.return_value = (mock_submission, [])
+        request_data = MultiDict({
+            'doi': '10.0001/123456',
+            'journal_ref': 'foo journal 10 2010: 12-345',
+            'report_num': 'foo report 13',
+            'acm_class': 'F.2.2; I.2.7',
+            'msc_class': '14J27'
+        })
+        data, code, headers = optional('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(mock_save.call_count, 1, "Events are generated")
+        event_types = [type(ev) for ev in mock_save.call_args[0]]
+        self.assertIn(events.SetReportNumber, event_types,
+                      "Sets report number")
+        self.assertIn(events.SetMSCClassification, event_types,
+                      "Sets MSC classification")
+        self.assertEqual(len(event_types), 2, "Only two events are generated")
 
 
 class TestMetadata(TestCase):
@@ -207,3 +325,61 @@ class TestMetadata(TestCase):
                               "Response data includes a form")
         self.assertIn('abstract', data['form'].errors,
                       'Validation errors are added to the form')
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_invalid_stack_is_raised(self, mock_load, mock_save):
+        """POST request results in an InvalidStack exception."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock(
+                title='the old title',
+                abstract='not the abstract that you are looking for',
+                authors_display='bloggs, j'
+            )
+        )
+        mock_load.return_value = (mock_submission, [])
+
+        def raise_invalid_stack(*args, **kwargs):
+            raise events.InvalidStack([])
+
+        mock_save.side_effect = raise_invalid_stack
+
+        request_data = MultiDict({
+            'title': 'a new, valid title',
+            'abstract': 'this abstract is at least twenty characters long',
+            'authors_display': 'j doe, j bloggs'
+        })
+        data, code, headers = metadata('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_save_error_is_raised(self, mock_load, mock_save):
+        """POST request results in an SaveError exception."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock(
+                title='the old title',
+                abstract='not the abstract that you are looking for',
+                authors_display='bloggs, j'
+            )
+        )
+        mock_load.return_value = (mock_submission, [])
+
+        def raise_save_error(*args, **kwargs):
+            raise events.SaveError('nope')
+
+        mock_save.side_effect = raise_save_error
+        request_data = MultiDict({
+            'title': 'a new, valid title',
+            'abstract': 'this abstract is at least twenty characters long',
+            'authors_display': 'j doe, j bloggs'
+        })
+        with self.assertRaises(InternalServerError):
+            metadata('POST', request_data, submission_id)

--- a/submit/controllers/tests/test_metadata.py
+++ b/submit/controllers/tests/test_metadata.py
@@ -5,6 +5,68 @@ from werkzeug import MultiDict
 from wtforms import Form
 from arxiv import status
 from submit.controllers import metadata, optional
+import events
+
+
+class TestOptional(TestCase):
+    """Tests for :func:`.optional`."""
+
+    @mock.patch('events.load')
+    def test_get_request_with_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        data, code, headers = optional('GET', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.load')
+    def test_post_request_with_no_data(self, mock_load):
+        """POST request has no form data."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        data, code, headers = optional('POST', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_with_required_data(self, mock_load, mock_save):
+        """POST request with all fields."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock()
+        )
+        mock_load.return_value = (mock_submission, [])
+        mock_save.return_value = (mock_submission, [])
+        request_data = MultiDict({
+            'doi': '10.0001/123456',
+            'journal_ref': 'foo journal 10 2010: 12-345',
+            'report_num': 'foo report 12',
+            'acm_class': 'F.2.2; I.2.7',
+            'msc_class': '14J26'
+        })
+        data, code, headers = optional('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        event_types = [type(ev) for ev in mock_save.call_args[0]]
+        self.assertIn(events.SetDOI, event_types, "Sets submission DOI")
+        self.assertIn(events.SetJournalReference, event_types,
+                      "Sets journal references")
+        self.assertIn(events.SetReportNumber, event_types,
+                      "Sets report number")
+        self.assertIn(events.SetACMClassification, event_types,
+                      "Sets ACM classification")
+        self.assertIn(events.SetMSCClassification, event_types,
+                      "Sets MSC classification")
 
 
 class TestMetadata(TestCase):
@@ -34,3 +96,114 @@ class TestMetadata(TestCase):
                          "Returns 400 bad request")
         self.assertIsInstance(data['form'], Form,
                               "Response data includes a form")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_with_required_data(self, mock_load, mock_save):
+        """POST request with title, abstract, and author names."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock(
+                title='the old title',
+                abstract='not the abstract that you are looking for',
+                authors_display='bloggs, j'
+            )
+        )
+        mock_load.return_value = (mock_submission, [])
+        mock_save.return_value = (mock_submission, [])
+        request_data = MultiDict({
+            'title': 'a new, valid title',
+            'abstract': 'this abstract is at least twenty characters long',
+            'authors_display': 'j doe, j bloggs'
+        })
+        data, code, headers = metadata('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        event_types = [type(ev) for ev in mock_save.call_args[0]]
+        self.assertIn(events.SetTitle, event_types, "Sets submission title")
+        self.assertIn(events.SetAbstract, event_types,
+                      "Sets submission abstract")
+        self.assertIn(events.UpdateAuthors, event_types,
+                      "Sets submission authors")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_with_unchanged_data(self, mock_load, mock_save):
+        """POST request with valid but unaltered data."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock(
+                title='the old title',
+                abstract='not the abstract that you are looking for',
+                authors_display='bloggs, j'
+            )
+        )
+        mock_load.return_value = (mock_submission, [])
+        mock_save.return_value = (mock_submission, [])
+        request_data = MultiDict({
+            'title': 'the old title',
+            'abstract': 'not the abstract that you are looking for',
+            'authors_display': 'bloggs, j'
+        })
+        data, code, headers = metadata('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(mock_save.call_count, 0, "No events are generated")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_some_changed_data(self, mock_load, mock_save):
+        """POST request with valid data; only the title has changed."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock(
+                title='the old title',
+                abstract='not the abstract that you are looking for',
+                authors_display='bloggs, j'
+            )
+        )
+        mock_load.return_value = (mock_submission, [])
+        mock_save.return_value = (mock_submission, [])
+        request_data = MultiDict({
+            'title': 'the new title',
+            'abstract': 'not the abstract that you are looking for',
+            'authors_display': 'bloggs, j'
+        })
+        data, code, headers = metadata('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(mock_save.call_count, 1, "One event is generated")
+        self.assertIsInstance(mock_save.call_args[0][0], events.SetTitle,
+                              "SetTitle event is generated")
+
+    @mock.patch('events.save')
+    @mock.patch('events.load')
+    def test_post_request_invalid_data(self, mock_load, mock_save):
+        """POST request with invalid data."""
+        submission_id = 2
+        mock_submission = mock.MagicMock(
+            submission_id=submission_id,
+            finalized=False,
+            metadata=mock.MagicMock(
+                title='the old title',
+                abstract='not the abstract that you are looking for',
+                authors_display='bloggs, j'
+            )
+        )
+        mock_load.return_value = (mock_submission, [])
+        mock_save.return_value = (mock_submission, [])
+        request_data = MultiDict({
+            'title': 'the new title',
+            'abstract': 'too short',
+            'authors_display': 'bloggs, j'
+        })
+        data, code, headers = metadata('POST', request_data, submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+        self.assertIn('abstract', data['form'].errors,
+                      'Validation errors are added to the form')

--- a/submit/controllers/tests/test_metadata.py
+++ b/submit/controllers/tests/test_metadata.py
@@ -1,0 +1,36 @@
+"""Tests for :mod:`submit.controllers.metadata`."""
+
+from unittest import TestCase, mock
+from werkzeug import MultiDict
+from wtforms import Form
+from arxiv import status
+from submit.controllers import metadata, optional
+
+
+class TestMetadata(TestCase):
+    """Tests for :func:`.metadata`."""
+
+    @mock.patch('events.load')
+    def test_get_request_with_submission(self, mock_load):
+        """GET request with a submission ID."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        data, code, headers = metadata('GET', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")
+
+    @mock.patch('events.load')
+    def test_post_request_with_no_data(self, mock_load):
+        """POST request has no form data."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id), []
+        )
+        data, code, headers = metadata('POST', MultiDict(), submission_id)
+        self.assertEqual(code, status.HTTP_400_BAD_REQUEST,
+                         "Returns 400 bad request")
+        self.assertIsInstance(data['form'], Form,
+                              "Response data includes a form")

--- a/submit/controllers/util.py
+++ b/submit/controllers/util.py
@@ -1,13 +1,17 @@
 """Helpers for controllers."""
 
-from typing import Callable, Any, Dict, Tuple, Optional
+from typing import Callable, Any, Dict, Tuple, Optional, List
+
 from werkzeug import MultiDict
 from werkzeug.exceptions import InternalServerError, NotFound
 from flask import url_for
+
 from wtforms.widgets import ListWidget, CheckboxInput, Select, HTMLString, \
     html_params
 from wtforms import StringField, PasswordField, SelectField, \
-    SelectMultipleField, Form
+    SelectMultipleField, Form, validators
+from wtforms.fields.core import UnboundField
+
 from arxiv import status
 import events
 
@@ -115,3 +119,88 @@ class OptGroupSelectField(SelectField):
     def _value(self) -> str:
         data: str = self.data
         return data
+
+
+class SubmissionMixin:
+    """
+    Provides submission-related integration for :class:`.Form`s.
+
+    Since the command events in :mod:`events` provide input validation, it
+    is convenient to instantiate those :class:`events.Event`s during form
+    validation. To do this, however, we need to know about the
+    :class:`events.Submission` and the event creator (an
+    :class:`events.User`). This mixin provides :prop:`.submission` and
+    :prop:`.creator` for that purpose.
+
+    Since we're instantiating the :class:`event.Event`s during form validation,
+    we also want to keep those around so that we don't have to create them
+    twice. So this mixin also provides :prop:`.events` and :meth:`._add_event`.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+       >>> from wtforms import Form, TextField, validators
+       >>> from submit.controllers.util import SubmissionMixin
+       >>> import events
+       >>>
+       >>> class FooForm(Form, SubmissionMixin):
+       ...     title = TextField('Title')
+       ...
+       ...     def validate_title(self, field):
+       ...         if self.submission.metadata.title == field.data:
+       ...             return
+       ...         self._validate_with_event(SetTitle, title=field.data)
+       ...
+       >>> form = FooForm(data)
+       >>> form.submission = submission
+       >>> form.creator = submitter
+       >>> form.validate()
+
+    """
+
+    def _set_submission(self, submission: events.Submission) -> None:
+        self._submission = submission
+
+    def _get_submission(self) -> events.Submission:
+        return self._submission
+
+    def _set_creator(self, creator: events.User) -> None:
+        self._creator = creator
+
+    def _get_creator(self) -> events.User:
+        return self._creator
+
+    submission = property(_get_submission, _set_submission)
+    creator = property(_get_creator, _set_creator)
+
+    def _add_event(self, event: events.Event) -> None:
+        if not hasattr(self, '_events'):
+            self._events = []
+        self._events.append(event)
+
+    def _validate_event(self, event_type: type, **data: Any) -> None:
+        event = event_type(creator=self.creator, **data)
+        self._add_event(event)
+        try:
+            event.validate(self.submission)
+        except events.InvalidEvent as e:
+            raise validators.ValidationError(e.message)
+
+    @property
+    def events(self) -> List[events.Event]:
+        """Command event instances created during form validation."""
+        if not hasattr(self, '_events'):
+            self._events = []
+        return self._events
+
+
+class FieldMixin:
+    """Provide a convenience classmethod for field names."""
+
+    @classmethod
+    def fields(cls):
+        """Convenience accessor for form field names."""
+        return [key for key in dir(cls)
+                if isinstance(getattr(cls, key), UnboundField)]

--- a/submit/controllers/util.py
+++ b/submit/controllers/util.py
@@ -151,7 +151,7 @@ class SubmissionMixin:
        ...     def validate_title(self, field):
        ...         if self.submission.metadata.title == field.data:
        ...             return
-       ...         self._validate_with_event(SetTitle, title=field.data)
+       ...         self._validate_event(SetTitle, title=field.data)
        ...
        >>> form = FooForm(data)
        >>> form.submission = submission

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -128,7 +128,7 @@ def cross_list(submission_id: int) -> Response:
             pagetitle='Choose Secondary Classifications',
             **data
         )
-        response = make_response(rendered, status.HTTP_200_OK)
+        response = make_response(rendered, code)
     elif code == status.HTTP_303_SEE_OTHER:
         return redirect(headers['Location'], code=code)
     return response
@@ -137,44 +137,61 @@ def cross_list(submission_id: int) -> Response:
 @blueprint.route('/<int:submission_id>/file_upload', methods=['GET'])
 def file_upload(submission_id: int) -> Response:
     """Render step 7, file add or edit."""
+    code = status.HTTP_200_OK
     rendered = render_template(
         "submit/file_upload.html",
         pagetitle='Add or Edit Files'
     )
-    response = make_response(rendered, status.HTTP_200_OK)
+    response = make_response(rendered, code)
     return response
 
 
 @blueprint.route('/<int:submission_id>/file_process', methods=['GET'])
 def file_process(submission_id: int) -> Response:
     """Render step 8, file processing."""
+    code = status.HTTP_200_OK
     rendered = render_template(
         "submit/file_process.html",
         pagetitle='Process Files'
     )
-    response = make_response(rendered, status.HTTP_200_OK)
+    response = make_response(rendered, code)
     return response
 
 
-@blueprint.route('/<int:submission_id>/add_metadata', methods=['GET'])
+@blueprint.route('/<int:submission_id>/add_metadata', methods=['GET', 'POST'])
 def add_metadata(submission_id: int) -> Response:
     """Render step 9, metadata."""
-    rendered = render_template(
-        "submit/add_metadata.html",
-        pagetitle='Add or Edit Metadata'
+    request_data = MultiDict(request.form.items(multi=True))
+    data, code, headers = controllers.metadata(request.method, request_data,
+                                               submission_id)
+    if code in [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST]:
+        rendered = render_template(
+            "submit/add_metadata.html",
+            pagetitle='Add or Edit Metadata',
+            **data
         )
-    response = make_response(rendered, status.HTTP_200_OK)
+        response = make_response(rendered, code)
+    elif code == status.HTTP_303_SEE_OTHER:
+        return redirect(headers['Location'], code=code)
     return response
 
 
-@blueprint.route('/<int:submission_id>/add_optional_metadata', methods=['GET'])
+@blueprint.route('/<int:submission_id>/add_optional_metadata',
+                 methods=['GET', 'POST'])
 def add_optional_metadata(submission_id: int) -> Response:
     """Render step 9, metadata."""
-    rendered = render_template(
-        "submit/add_optional_metadata.html",
-        pagetitle='Add or Edit Metadata'
-        )
-    response = make_response(rendered, status.HTTP_200_OK)
+    request_data = MultiDict(request.form.items(multi=True))
+    data, code, headers = controllers.optional(request.method, request_data,
+                                               submission_id)
+    if code in [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST]:
+        rendered = render_template(
+            "submit/add_optional_metadata.html",
+            pagetitle='Add or Edit Metadata',
+            **data
+            )
+        response = make_response(rendered, code)
+    elif code == status.HTTP_303_SEE_OTHER:
+        response = redirect(headers['Location'], code=code)
     return response
 
 
@@ -185,7 +202,8 @@ def final_preview(submission_id: int) -> Response:
         "submit/final_preview.html",
         pagetitle='Preview and Approve'
     )
-    response = make_response(rendered, status.HTTP_200_OK)
+    code = status.HTTP_200_OK
+    response = make_response(rendered, code)
     return response
 
 
@@ -196,5 +214,6 @@ def confirm_submit(submission_id: int) -> Response:
         "submit/confirm_submit.html",
         pagetitle='Submission Confirmed'
     )
-    response = make_response(rendered, status.HTTP_200_OK)
+    code = status.HTTP_200_OK
+    response = make_response(rendered, code)
     return response

--- a/submit/templates/submit/add_metadata.html
+++ b/submit/templates/submit/add_metadata.html
@@ -5,36 +5,33 @@
 {% block within_content %}
 <h2 class="is-size-4">Add or edit metadata</h2>
 
-<div class="field">
-  <div class="control">
-    <label class="label">*Title <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input" type="text" placeholder="Title here">
-  </div>
-</div>
+<form method="POST" action="{{ url_for('ui.add_metadata', submission_id=submission_id) }}">
+  {% for field in form %}
 
-<div class="field">
-  <div class="control">
-    <label class="label">*Author(s) <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input" type="text" placeholder="Authors here">
-    <p class="help">use <code>Forename Surname</code> or <code>I. Surname</code>; separate individual authors with a comma or 'and'</p>
+  <div class="field">
+    <div class="control">
+      <label class="label">*{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+      {% if field.errors %}
+        {{ field(class="input is-warning")|safe }}
+      {% else %}
+        {{ field(class="input")|safe }}
+      {% endif %}
+      {% if field.errors %}
+        <div class="help is-warning">
+          {% for error in field.errors %}
+              {{ error }}
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% if field.description %}
+      <p class="help has-text-grey">
+        {{ field.description|safe }}
+      </p>
+      {% endif %}
+    </div>
   </div>
-</div>
+  {% endfor %}
 
-<div class="field">
-  <div class="control">
-    <label class="label">*Abstract <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input" type="textarea" placeholder="Abstract here">
-    <p class="help">Limit of 1920 characters</p>
-  </div>
-</div>
-
-<div class="field">
-  <div class="control">
-    <label class="label">Comments <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input" type="text" placeholder="Comments here">
-    <p class="help">supplemental information such as number of pages or figures, conference information</p>
-  </div>
-</div>
-
-{{ submit_macros.submit_nav() }}
+  {{ submit_macros.submit_nav() }}
+</form>
 {% endblock within_content %}

--- a/submit/templates/submit/add_metadata.html
+++ b/submit/templates/submit/add_metadata.html
@@ -7,10 +7,9 @@
 
 <form method="POST" action="{{ url_for('ui.add_metadata', submission_id=submission_id) }}">
   {% for field in form %}
-
   <div class="field">
     <div class="control">
-      <label class="label">*{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
       {% if field.errors %}
         {{ field(class="input is-warning")|safe }}
       {% else %}

--- a/submit/templates/submit/add_optional_metadata.html
+++ b/submit/templates/submit/add_optional_metadata.html
@@ -10,7 +10,7 @@
 
   <div class="field">
     <div class="control">
-      <label class="label">*{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
       {% if field.errors %}
         {{ field(class="input is-warning")|safe }}
       {% else %}

--- a/submit/templates/submit/add_optional_metadata.html
+++ b/submit/templates/submit/add_optional_metadata.html
@@ -8,7 +8,7 @@
 <form method="POST" action="{{ url_for('ui.add_optional_metadata', submission_id=submission_id) }}">
   {% for field in form %}
 
-  <div class="field">
+  <div class="field is-short-field">
     <div class="control">
       <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
       {% if field.errors %}

--- a/submit/templates/submit/add_optional_metadata.html
+++ b/submit/templates/submit/add_optional_metadata.html
@@ -5,45 +5,33 @@
 {% block within_content %}
 <h2 class="is-size-4">Add or edit optional metadata</h2>
 
-<div class="field">
-  <div class="control">
-    <label class="label">Report Number <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input is-short-field" type="text" placeholder="leave blank if you don't have one">
-    <p class="help">If your institution supplies a report number, enter it here.</p>
-  </div>
-</div>
+<form method="POST" action="{{ url_for('ui.add_optional_metadata', submission_id=submission_id) }}">
+  {% for field in form %}
 
-<div class="field">
-  <div class="control">
-    <label class="label">Journal Reference <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input is-short-field" type="text" placeholder="Jref placeholder">
-    <p class="help">Journal reference information, if available.</p>
+  <div class="field">
+    <div class="control">
+      <label class="label">*{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+      {% if field.errors %}
+        {{ field(class="input is-warning")|safe }}
+      {% else %}
+        {{ field(class="input")|safe }}
+      {% endif %}
+      {% if field.errors %}
+        <div class="help is-warning">
+          {% for error in field.errors %}
+              {{ error }}
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% if field.description %}
+      <p class="help has-text-grey">
+        {{ field.description|safe }}
+      </p>
+      {% endif %}
+    </div>
   </div>
-</div>
+  {% endfor %}
 
-<div class="field">
-  <div class="control">
-    <label class="label">DOI <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input is-short-field" type="text" placeholder="DOI Placeholder">
-    <p class="help">Full DOI only if available. How does a person enter a second DOI?</p>
-  </div>
-</div>
-
-<div class="field">
-  <div class="control">
-    <label class="label">ACM Class <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input is-short-field" type="text" placeholder="example: F.2.2; I.2.7">
-    <p class="help">show only on CS?</p>
-  </div>
-</div>
-
-<div class="field">
-  <div class="control">
-    <label class="label">MSC Class <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-    <input class="input is-short-field" type="text" placeholder="example: 14J60 (Primary),  14F05, 14J26 (Secondary)">
-    <p class="help">Show only on math?</p>
-  </div>
-</div>
-
-{{ submit_macros.submit_nav() }}
+  {{ submit_macros.submit_nav() }}
+</form>
 {% endblock within_content %}

--- a/submit/templates/submit/add_optional_metadata.html
+++ b/submit/templates/submit/add_optional_metadata.html
@@ -7,7 +7,6 @@
 
 <form method="POST" action="{{ url_for('ui.add_optional_metadata', submission_id=submission_id) }}">
   {% for field in form %}
-
   <div class="field is-short-field">
     <div class="control">
       <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3451594/41743150-fd73cef2-756d-11e8-9c8c-8e6a6025a8db.png)
![image](https://user-images.githubusercontent.com/3451594/41743212-1463fc54-756e-11e8-82e1-2de58245a65c.png)

This delivers the core and optional metadata controllers. I also spent some time working on a more convenient integration with the core events package. The upshot is that we want to leverage the core events validation for validating data on the form. If this looks like a promising direction, I'll refactor the other controllers to use this pattern.

Would like to merge this by noon tomorrow (Friday), if possible. You'll have to manually skip over to step 9 when testing.