### PR TITLE
ARXIVNG-989: delete files template

### DIFF
--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -217,3 +217,15 @@ def confirm_submit(submission_id: int) -> Response:
     code = status.HTTP_200_OK
     response = make_response(rendered, code)
     return response
+
+
+@blueprint.route('/<int:submission_id>/confirm_delete', methods=['GET'])
+def confirm_delete(submission_id: int) -> Response:
+    """Confirm user initiated file deletion."""
+    rendered = render_template(
+        "submit/confirm_delete.html",
+        pagetitle='Delete Files'
+    )
+    code = status.HTTP_200_OK
+    response = make_response(rendered, code)
+    return response

--- a/submit/templates/submit/base.html
+++ b/submit/templates/submit/base.html
@@ -8,8 +8,8 @@
   <h1 class="title">{% block title %}Submit an Article{% endblock title %}</h1>
   <div class="message">
     <div class="message-body">
-    {{ submit_macros.progress_bar(submission_id) }}
-  </div>
+      {{ submit_macros.progress_bar(submission_id) }}
+    </div>
   </div>
   <content>
     {% if form and form.errors %}

--- a/submit/templates/submit/confirm_delete.html
+++ b/submit/templates/submit/confirm_delete.html
@@ -4,14 +4,17 @@
 
 {% block within_content %}
 <h2 class="is-size-4">Delete Files</h2>
-<div class="container">
+<div class="container" style="max-width: 640px">
   <div class="message is-danger is-inline-block">
     <div class="message-body">
-      <h3 class="is-size-4 has-text-weight-bold has-text-primary">This action will remove the following files from arXiv:</h3>
+      <h3 class="is-size-5 has-text-weight-bold has-text-primary">This action will remove the following files from arXiv:</h3>
       <ul>
         <li>file-to-be-deleted</li>
       </ul>
-      <a class="button" href="#">Keep these files</a> <a class="button is-primary" href="#">Delete these files</a>
+      <div class="buttons is-centered">
+          <a class="button" href="#">Keep these files</a>
+          <a class="button is-primary" href="#">Delete these files</a>
+      </div>
     </div>
   </div>
 </div>

--- a/submit/templates/submit/confirm_delete.html
+++ b/submit/templates/submit/confirm_delete.html
@@ -1,0 +1,19 @@
+{% extends "submit/base.html" %}
+
+{% import "submit/submit_macros.html" as submit_macros %}
+
+{% block within_content %}
+<h2 class="is-size-4">Delete Files</h2>
+<div class="container">
+  <div class="message is-danger is-inline-block">
+    <div class="message-body">
+      <h3 class="is-size-4 has-text-weight-bold has-text-primary">This action will remove the following files from arXiv:</h3>
+      <ul>
+        <li>file-to-be-deleted</li>
+      </ul>
+      <a class="button" href="#">Keep these files</a> <a class="button is-primary" href="#">Delete these files</a>
+    </div>
+  </div>
+</div>
+
+{% endblock within_content %}


### PR DESCRIPTION
Simple template to implement confirmation dialog screen.
Buttons are written as links rather than form elements; assumed we didn't need a form for a yes/no confirmation but I may be mistaken?

## Desktop:

![screen shot 2018-07-23 at 11 25 12 am](https://user-images.githubusercontent.com/17456668/43086450-53fc1944-8e6b-11e8-889c-6f1a0a90163f.png)

## Mobile:

![screen shot 2018-07-23 at 11 25 31 am](https://user-images.githubusercontent.com/17456668/43086449-53ebb284-8e6b-11e8-8212-3ac75eca2658.png)

