### PR TITLE
ARXIVNG-985 change labels with confusing terms; ARXIVNG-987 label box for Selected Categories

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-arxiv-base = "==0.7.1"
+arxiv-base = {git = "https://github.com/cul-it/arxiv-base.git", editable = true, ref = "develop"}
 dataclasses = "*"
 Flask = "*"
 jsonschema = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4ca2db4e8ae2ad923a75e2bedf50562c6dbc12549158c07a2aba1a4312792d2d"
+            "sha256": "15b3703e810cbccade2609507de5fb35cd8cb1e2014038b8831d6427d1aab184"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -15,11 +15,9 @@
     },
     "default": {
         "arxiv-base": {
-            "hashes": [
-                "sha256:e386f771296d2971d0435640a732dc3c77c4f7856ddabfe0daba9e3bafbd6dfb"
-            ],
-            "index": "pypi",
-            "version": "==0.7.1"
+            "editable": true,
+            "git": "https://github.com/cul-it/arxiv-base.git",
+            "ref": "94ef397c0078c215ecce9c99b7ff7ef5192ecd0a"
         },
         "arxiv-submission-events": {
             "hashes": [
@@ -36,6 +34,20 @@
             "index": "pypi",
             "version": "==2.1.3"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:6ab3147ae26399fc33b4af77491d1df985e0ebfd6fb64980d96ad33d91ba96ba",
+                "sha256:f0354982ab28e0f3bc3d969b28e07c1bebb87c3c7a28105c45ee509a3dfc52c6"
+            ],
+            "version": "==1.7.63"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:a72d99f48f3b65c4440b1c059f9063b9d353692c78227ad290709590e041c17e",
+                "sha256:bbafb2a29e3a249c9d6ae00109bdbdb11049d0d860dc5531ff95ba86d61e587c"
+            ],
+            "version": "==1.10.63"
+        },
         "click": {
             "hashes": [
                 "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
@@ -50,6 +62,14 @@
             ],
             "index": "pypi",
             "version": "==0.6"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "version": "==0.14"
         },
         "flask": {
             "hashes": [
@@ -79,6 +99,13 @@
             ],
             "version": "==2.10"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64",
+                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"
+            ],
+            "version": "==0.9.3"
+        },
         "jsonschema": {
             "hashes": [
                 "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
@@ -93,33 +120,45 @@
             ],
             "version": "==1.0"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==2.7.3"
+        },
         "pytz": {
             "hashes": [
-                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
-                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
+                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
+                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
             ],
             "index": "pypi",
-            "version": "==2018.4"
+            "version": "==2018.5"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
-                "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
-                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
-                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
-                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
-                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
-                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
-                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
-                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
-                "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
-                "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
-                "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
-                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
             "index": "pypi",
-            "version": "==3.12"
+            "version": "==3.13"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
+                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
+            ],
+            "version": "==0.1.13"
         },
         "six": {
             "hashes": [
@@ -130,17 +169,17 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:2d5f08f714a886a1382c18be501e614bce50d362384dc089474019ce0768151c"
+                "sha256:72325e67fb85f6e9ad304c603d83626d1df684fdf0c7ab1f0352e71feeab69d8"
             ],
             "index": "pypi",
-            "version": "==1.2.8"
+            "version": "==1.2.10"
         },
         "uwsgi": {
             "hashes": [
-                "sha256:3dc2e9b48db92b67bfec1badec0d3fdcc0771316486c5efa3217569da3528bf2"
+                "sha256:d2318235c74665a60021a4fc7770e9c2756f9fc07de7b8c22805efe85b5ab277"
             ],
             "index": "pypi",
-            "version": "==2.0.17"
+            "version": "==2.0.17.1"
         },
         "webencodings": {
             "hashes": [
@@ -167,10 +206,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
-                "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
+                "sha256:0a0c484279a5f08c9bcedd6fa9b42e378866a7dcc695206b92d59dc9f2d9760d",
+                "sha256:218e36cf8d98a42f16214e8670819ce307fa707d1dcf7f9af84c7aede1febc7f"
             ],
-            "version": "==1.6.5"
+            "version": "==2.0.1"
         },
         "certifi": {
             "hashes": [
@@ -191,10 +230,13 @@
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
                 "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
+                "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
                 "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
                 "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
                 "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
                 "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
                 "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
@@ -308,11 +350,11 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:1b899802a89b67bb68f30d788bba49b61b1f28779436f06b75c03495f9d6ea5c",
-                "sha256:f472645347430282d62d1f97d12ccb8741f19f1572b7cf30b58280e4e0818739"
+                "sha256:673ea75fb750289b7d1da1331c125dc62fc1c3a8db9129bb372ae7b7d5bf300a",
+                "sha256:c770605a579fdd4a014e9f0a34b6c7a36ce69b08100ff728e96e27445cef3b3c"
             ],
             "index": "pypi",
-            "version": "==0.610"
+            "version": "==0.620"
         },
         "nose2": {
             "hashes": [
@@ -332,11 +374,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:a48070545c12430cfc4e865bf62f5ad367784765681b3db442d8230f0960aa3c",
-                "sha256:fff220bcb996b4f7e2b0f6812fd81507b72ca4d8c4d05daf2655c333800cb9b3"
+                "sha256:2c90a24bee8fae22ac98061c896e61f45c5b73c2e0511a4bf53f99ba56e90434",
+                "sha256:454532779425098969b8f54ab0f056000b883909f69d05905ea114df886e3251"
             ],
             "index": "pypi",
-            "version": "==1.9.2"
+            "version": "==2.0.1"
         },
         "requests": {
             "hashes": [
@@ -362,6 +404,8 @@
         "typed-ast": {
             "hashes": [
                 "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
+                "sha256:10703d3cec8dcd9eef5a630a04056bbc898abc19bac5691612acba7d1325b66d",
+                "sha256:1f6c4bd0bdc0f14246fd41262df7dfc018d65bb05f6e16390b7ea26ca454a291",
                 "sha256:25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a",
                 "sha256:29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9",
                 "sha256:2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892",
@@ -373,6 +417,9 @@
                 "sha256:6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85",
                 "sha256:79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6",
                 "sha256:8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46",
+                "sha256:898f818399cafcdb93cbbe15fc83a33d05f18e29fb498ddc09b0214cdfc7cd51",
+                "sha256:94b091dc0f19291adcb279a108f5d38de2430411068b219f41b343c03b28fb1f",
+                "sha256:a26863198902cda15ab4503991e8cf1ca874219e0118cbf07c126bce7c4db129",
                 "sha256:a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c",
                 "sha256:bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea",
                 "sha256:c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863",

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -30,8 +30,8 @@ class CoreMetadataForm(Form, FieldMixin, SubmissionMixin):
         '*Authors',
         validators=[validators.DataRequired()],
         description=(
-            "use <code>Forename Surname</code> or <code>I. "
-            "Surname</code>; separate individual authors with "
+            "use <code>GivenName(s) FamilyName(s)</code> or <code>I. "
+            "FamilyName</code>; separate individual authors with "
             "a comma or 'and'."
         )
     )

--- a/submit/static/css/submit.css
+++ b/submit/static/css/submit.css
@@ -8,6 +8,13 @@
   max-width: 25rem; }
 
 .form-margin {
-  margin-top: 0.4em;
-  margin-bottom: 0.4em; }
+  margin: 0.4em 0; }
+
+/* overrides for this form only? may move to base */
+.field:not(:last-child) {
+  margin-bottom: 1.25em; }
+
+.label:not(:last-child) {
+  margin-bottom: 0.25em; }
+
 /*# sourceMappingURL=submit.css.map */

--- a/submit/static/css/submit.css.map
+++ b/submit/static/css/submit.css.map
@@ -1,6 +1,6 @@
 {
 "version": 3,
-"mappings": "AAAA,WAAW;EACT,UAAU,EAAE,GAAG;;AAEjB,aAAa;EACX,aAAa,EAAE,cAAc;;AAE/B,eAAe;EACb,SAAS,EAAE,KAAK",
+"mappings": "AAAA,WAAW;EACT,UAAU,EAAE,GAAG;;AAEjB,aAAa;EACX,aAAa,EAAE,cAAc;;AAE/B,eAAe;EACb,SAAS,EAAE,KAAK;;AAElB,YAAY;EACV,MAAM,EAAE,OAAM;;;AAIhB,uBAAuB;EACrB,aAAa,EAAE,MAAM;;AAEvB,uBAAuB;EACrB,aAAa,EAAE,MAAK",
 "sources": ["../sass/submit.sass"],
 "names": [],
 "file": "submit.css"

--- a/submit/static/sass/submit.sass
+++ b/submit/static/sass/submit.sass
@@ -9,3 +9,11 @@
 
 .form-margin
   margin: .4em 0
+
+/* overrides for this form only? may move to base */
+
+.field:not(:last-child)
+  margin-bottom: 1.25em
+
+.label:not(:last-child)
+  margin-bottom: .25em

--- a/submit/templates/submit/add_metadata.html
+++ b/submit/templates/submit/add_metadata.html
@@ -11,21 +11,21 @@
     <div class="control">
       <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
       {% if field.errors %}
-        {{ field(class="input is-warning")|safe }}
-      {% else %}
-        {{ field(class="input")|safe }}
-      {% endif %}
-      {% if field.errors %}
-        <div class="help is-warning">
+        <div class="help is-danger">
           {% for error in field.errors %}
               {{ error }}
           {% endfor %}
         </div>
       {% endif %}
       {% if field.description %}
-      <p class="help has-text-grey">
+      <p class="help has-text-grey is-marginless">
         {{ field.description|safe }}
       </p>
+      {% endif %}
+      {% if field.errors %}
+        {{ field(class="input is-danger")|safe }}
+      {% else %}
+        {{ field(class="input")|safe }}
       {% endif %}
     </div>
   </div>

--- a/submit/templates/submit/add_optional_metadata.html
+++ b/submit/templates/submit/add_optional_metadata.html
@@ -11,21 +11,21 @@
     <div class="control">
       <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
       {% if field.errors %}
-        {{ field(class="input is-warning")|safe }}
-      {% else %}
-        {{ field(class="input")|safe }}
-      {% endif %}
-      {% if field.errors %}
-        <div class="help is-warning">
+        <div class="help is-danger">
           {% for error in field.errors %}
               {{ error }}
           {% endfor %}
         </div>
       {% endif %}
       {% if field.description %}
-      <p class="help has-text-grey">
+      <p class="help has-text-grey is-marginless">
         {{ field.description|safe }}
       </p>
+      {% endif %}
+      {% if field.errors %}
+        {{ field(class="input is-danger")|safe }}
+      {% else %}
+        {{ field(class="input")|safe }}
       {% endif %}
     </div>
   </div>

--- a/submit/templates/submit/authorship.html
+++ b/submit/templates/submit/authorship.html
@@ -3,7 +3,7 @@
 {% import "submit/submit_macros.html" as submit_macros %}
 
 {% block within_content %}
-<h2 class="is-size-4">Confirm authorship or proxy approval</h2>
+<h2 class="is-size-4">Confirm authorship</h2>
 <form method="POST" action="{{ url_for('ui.authorship',submission_id=submission_id) }}">
   {% for field in form.authorship %}
     <div class="field">
@@ -17,19 +17,19 @@
   {% endfor %}
   {% if form.authorship.errors %}
     {% for error in form.authorship.errors %}
-      <p class="help is-warning">{{ error }}</p>
+      <p class="help is-danger">{{ error }}</p>
     {% endfor %}
   {% endif %}
 
   <div class="field">
-    <div class="control" style="margin-left: 1.25em">
+    <div class="control" style="margin-left: 2em">
       <div class="checkbox">
         {{ form.proxy }}
         {{ form.proxy.label }} <a href="help link as modal"><i class="fa fa-question-circle is-info"></i></a>
       </div>
       {% if form.proxy.errors %}
         {% for error in form.proxy.errors %}
-          <p class="help is-warning">{{ error }}</p>
+          <p class="help is-danger">{{ error }}</p>
         {% endfor %}
       {% endif %}
     </div>

--- a/submit/templates/submit/classification.html
+++ b/submit/templates/submit/classification.html
@@ -6,18 +6,20 @@
 <h2 class="is-size-4">Choose a primary classification</h2>
 <form method="POST" action="{{ url_for('ui.classification', submission_id=submission_id) }}">
   {% with field = form.category %}
-  <div class="field">
+  <div class="field breathe-vertical">
     <div class="control">
-      {{ field.label }}
+      <div class="is-block">
+      {{ field.label(class_="label is-inline-block") }} <a href="help link as modal"><i class="fa fa-question-circle is-info"></i></a>
+    </div>
       <div class="select">
       {% if field.errors %}
-        {{ field(class="is-warning")|safe }}
+        {{ field(class="is-danger")|safe }}
       {% else %}
         {{ field()|safe }}
       {% endif %}
       </div>
       {% if field.errors %}
-        <div class="help is-warning">
+        <div class="help is-danger">
           {% for error in field.errors %}
               {{ error }}
           {% endfor %}
@@ -35,7 +37,7 @@
   <div class="message is-link is-inline-block submit-nav">
     <div class="message-body">
       <p><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>
-      You may add archives to the list and change defaults in your <a href="#">user account settings</a>.</p>
+      You may add categories to the list and change defaults in your <a href="#">user account settings</a>.</p>
     </div>
   </div>
   {{ submit_macros.submit_nav() }}

--- a/submit/templates/submit/cross_list.html
+++ b/submit/templates/submit/cross_list.html
@@ -5,8 +5,8 @@
 {% block within_content %}
 <h2 class="is-size-4">Choose cross-list classifications (optional)</h2>
 
-
-<div class="message is-info is-inline-block submit-nav">
+<div class="message is-link is-inline-block submit-nav">
+  <div class="message-header"><p class="is-size-6 is-white has-text-weight-semibold">Selected Categories</p></div>
   <div class="message-body">
     <p class="has-text-weight-bold" style="margin-bottom: .5em">
       <span class="tag is-link">{{ primary.id }}</span> {{ primary.name }}
@@ -32,18 +32,19 @@
 <form method="POST" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
   {{ form.operation }}
   {% with field = form.category %}
-  <label>Add a cross-list category</label>
-  <div class="field has-addons">
+  <label class="label" style="margin-top: 3em">Add a cross-list category
+  <a href="help link as modal"><i class="fa fa-question-circle is-info"></i></a></label>
+  <div class="field has-addons" style="margin-bottom: 3em">
     <div class="control">
       <div class="select">
       {% if field.errors %}
-        {{ field(class="is-warning")|safe }}
+        {{ field(class="is-danger")|safe }}
       {% else %}
         {{ field()|safe }}
       {% endif %}
       </div>
       {% if field.errors %}
-        <div class="help is-warning">
+        <div class="help is-danger">
           {% for error in field.errors %}
               {{ error }}
           {% endfor %}

--- a/submit/templates/submit/file_process.html
+++ b/submit/templates/submit/file_process.html
@@ -9,7 +9,7 @@
   <div class="column">
     <div class="field">
       <div class="control">
-        <label class="label">Primary compiler:</label>
+        <label class="label">Compiler:</label>
         <div class="select">
           <select>
             <option>pdflatex</option>

--- a/submit/templates/submit/license.html
+++ b/submit/templates/submit/license.html
@@ -9,13 +9,11 @@
   <div class="field">
   {% for subfield in form.license %}
     <div class="control">
-
       <label class="radio">
         {{subfield}}
+        {{ subfield.label.text }}
       {% if subfield.data %}
-          <a href="{{subfield.data}}">{{ subfield.label.text }}</a>
-      {% else %}
-          {{subfield.label.text }}
+          <a href="{{subfield.data}}" title="license info"><i class="fa fa-question-circle is-info"></i></a>
       {% endif %}
       </label>
     </div>
@@ -24,7 +22,7 @@
 
   {% if form.license.errors %}
     {% for error in form.license.errors %}
-      <p class="help is-warning">{{ error }}</p>
+      <p class="help is-danger">{{ error }}</p>
     {% endfor %}
   {% endif %}
 

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -5,11 +5,36 @@
 {% block within_content %}
 
 <h2 class="is-size-4">Verify your contact information</h2>
-<p><span class="label">First or given name:</span> Ima</p>
-<p><span class="label">Last or family name:</span> Nauthor</p>
-<p><span class="label">Suffix:</span></p>
-<p><span class="label">Affiliation:</span> Cornell University</p>
-<p><span class="label">E-mail:</span> ian413@cornell.edu</p>
+<div class="field is-horizontal">
+    <div class="field-label">
+      <span class="has-text-weight-semibold">First or given name:</span>
+    </div>
+    <div class="field-body"><span class="is-expanded">Ima</span></div>
+</div>
+<div class="field is-horizontal">
+  <div class="field-label">
+    <span class="has-text-weight-semibold">Last or family name:</span>
+  </div>
+   <div class="field-body">Nauthor</div>
+</div>
+<div class="field is-horizontal">
+  <div class="field-label">
+    <span class="has-text-weight-semibold">Suffix:</span>
+  </div>
+  <div class="field-body">&nbsp;</div>
+</div>
+<div class="field is-horizontal">
+  <div class="field-label">
+    <span class="has-text-weight-semibold">Affiliation:</span>
+  </div>
+  <div class="field-body">Cornell University</div>
+</div>
+<div class="field is-horizontal">
+  <div class="field-label">
+    <span class="has-text-weight-semibold">E-mail:</span>
+  </div>
+  <div class="field-body">ian413@cornell.edu</div>
+</div>
 
 <form method="POST" action="{% if submission_id %}{{ url_for('ui.verify_user', submission_id=submission_id) }}{% else %}{{ url_for('ui.verify_user') }}{% endif %}">
   <div class="field">

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -5,8 +5,8 @@
 {% block within_content %}
 
 <h2 class="is-size-4">Verify your contact information</h2>
-<p><span class="label">Forename:</span> Ima</p>
-<p><span class="label">Surname:</span> Nauthor</p>
+<p><span class="label">First or given name:</span> Ima</p>
+<p><span class="label">Last or family name:</span> Nauthor</p>
 <p><span class="label">Suffix:</span></p>
 <p><span class="label">Affiliation:</span> Cornell University</p>
 <p><span class="label">E-mail:</span> ian413@cornell.edu</p>
@@ -19,7 +19,7 @@
         {{ form.verify_user.label }}
       </div>
       {% for error in form.verify_user.errors %}
-        <p class="help is-warning">{{ error }}</p>
+        <p class="help is-danger">{{ error }}</p>
       {% endfor %}
     </div>
 </div>

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -7,13 +7,13 @@
 <h2 class="is-size-4">Verify your contact information</h2>
 <div class="field is-horizontal">
     <div class="field-label">
-      <span class="has-text-weight-semibold">First or given name:</span>
+      <span class="has-text-weight-semibold">First or given name(s):</span>
     </div>
     <div class="field-body"><span class="is-expanded">Ima</span></div>
 </div>
 <div class="field is-horizontal">
   <div class="field-label">
-    <span class="has-text-weight-semibold">Last or family name:</span>
+    <span class="has-text-weight-semibold">Last or family name(s):</span>
   </div>
    <div class="field-body">Nauthor</div>
 </div>


### PR DESCRIPTION
Changes made in pursuit of correcting all of the language that was identified in the usability study:
- Proxy (removed from title on authorship page)
- Forename/surname (changed to "First or Given"/"Last or Family" on verify_user and add_metadata pages)
- Primary compiler (removed "primary"), and I expect this page will change further when we actually do the UI for compilation service integration
- Archives (mentioned in an info box on the Classification page, changed to "categories")
- Cross-list (added info link)

- Box on cross-list page labeled with "Secondary Categories"
![screen shot 2018-07-25 at 3 53 49 pm](https://user-images.githubusercontent.com/17456668/43225846-2a87ac4a-9028-11e8-8c80-13edf7b1f084.png)

Opportunistic layout, accessibility, and spacing edits were also made. Incomplete, but better. Will continue to make incremental improvements in this manner.

Labels on metadata page were moved to above the input fields for better screen reader legibility (having instructions and errors come before the field). Am on the fence about this, as it may be more salient for AJAX-style validation, but it makes sense to me.
![screen shot 2018-07-25 at 4 36 34 pm](https://user-images.githubusercontent.com/17456668/43226139-f9478e6a-9028-11e8-9d20-bb276291b557.png)
