### PR TITLE
ARXIVNG-986 add and label trash can icon

### DIFF
--- a/submit/static/css/submit.css
+++ b/submit/static/css/submit.css
@@ -10,3 +10,8 @@
 
 .label:not(:last-child) {
   margin-bottom: 0.25em; }
+
+.buttons .button:not(:last-child) {
+  margin-right: 0.75rem; }
+
+/*# sourceMappingURL=submit.css.map */

--- a/submit/static/css/submit.css.map
+++ b/submit/static/css/submit.css.map
@@ -1,6 +1,6 @@
 {
 "version": 3,
-"mappings": "AAAA,WAAW;EACT,UAAU,EAAE,GAAG;;AAEjB,aAAa;EACX,aAAa,EAAE,cAAc;;AAE/B,eAAe;EACb,SAAS,EAAE,KAAK;;AAElB,YAAY;EACV,MAAM,EAAE,OAAM;;;AAIhB,uBAAuB;EACrB,aAAa,EAAE,MAAM;;AAEvB,uBAAuB;EACrB,aAAa,EAAE,MAAK",
+"mappings": "AAAA,WAAW;EACT,UAAU,EAAE,GAAG;;AAEjB,YAAY;EACV,MAAM,EAAE,OAAM;;;AAIhB,uBAAuB;EACrB,aAAa,EAAE,MAAM;;AAEvB,uBAAuB;EACrB,aAAa,EAAE,MAAK;;AAEtB,iCAAiC;EAC/B,YAAY,EAAE,OAAM",
 "sources": ["../sass/submit.sass"],
 "names": [],
 "file": "submit.css"

--- a/submit/static/sass/submit.sass
+++ b/submit/static/sass/submit.sass
@@ -11,3 +11,6 @@
 
 .label:not(:last-child)
   margin-bottom: .25em
+
+.buttons .button:not(:last-child)
+  margin-right: .75rem

--- a/submit/templates/submit/submit_macros.html
+++ b/submit/templates/submit/submit_macros.html
@@ -1,9 +1,10 @@
 {% macro submit_nav() %}
 
   <div class="buttons submit-nav" role="navigation">
-      <button name="action" class="button" value="previous" aria-label="Previous">Previous</button>
+      <button name="cancel" class="button has-text-grey is-light is-outlined" style="border:0" value="cancel" aria-label="Cancel submission" title="Cancel submission"><span class="icon"><i class="fa fa-trash fa-lg"></i></button>
+      <button name="action" class="button" value="previous" aria-label="Go back one step">Go Back</button>
       <button name="action" type="submit" class="button" value="save_exit" aria-label="Save and Exit">Save and Exit</button>
-      <button name="action" class="button is-link" value="next" aria-label="Next">Next</button>
+      <button name="action" class="button is-link" value="next" aria-label="Save and continue">Save and Continue</button>
   </div>
 
 {% endmacro %}


### PR DESCRIPTION
In concordance with feedback from usability testing, this small PR adds the "cancel/delete submission" function with a trash can icon in the navigation buttons. It has a hover label to indicate function.

NOTE: this PR does not implement functionality for the trash can icon or cancel/delete function. If we don't want to expose this functionality now, easy enough to just hide the button.

![screen shot 2018-07-31 at 11 24 11 am](https://user-images.githubusercontent.com/17456668/43469652-a86b3402-94b4-11e8-820f-bb7388ee5a98.png)
