### PR TITLE
ARXIVNG-1135 highlight files that were just uploaded 

### DIFF
--- a/submit/controllers/tests/test_upload.py
+++ b/submit/controllers/tests/test_upload.py
@@ -229,7 +229,7 @@ class TestDelete(TestCase):
             ), []
         )
         file_path = 'anc/foo.jpeg'
-        params = MultiDict({'name': file_path})
+        params = MultiDict({'path': file_path})
         response_data, code, headers = upload.delete(
             'GET', params, self.session, submission_id, 'footoken'
         )

--- a/submit/controllers/upload.py
+++ b/submit/controllers/upload.py
@@ -182,7 +182,7 @@ def delete(method: str, params: MultiDict, session: Session,
     the ``confirmed`` parameter.
 
     The process can be initiated with a GET request that contains the
-    ``name`` (key) for the file to be deleted. For example, a button on
+    ``path`` (key) for the file to be deleted. For example, a button on
     the upload interface may link to the deletion route with the file path
     as a query parameter. This will generate a deletion confirmation form,
     which can be POSTed to complete the action.
@@ -227,7 +227,7 @@ def delete(method: str, params: MultiDict, session: Session,
         # request is the file path. This way there is no way for a GET request
         # to trigger actual deletion. The user must explicitly indicate via
         # a valid POST that the file should in fact be deleted.
-        form = DeleteFileForm(MultiDict({'file_path': params['name']}))
+        form = DeleteFileForm(MultiDict({'file_path': params['path']}))
         response_data.update({'form': form})
         return response_data, status.HTTP_200_OK, {}
     elif method == 'POST':

--- a/submit/factory.py
+++ b/submit/factory.py
@@ -26,4 +26,5 @@ def create_ui_web_app() -> Flask:
     wrap(app, [auth.middleware.AuthMiddleware])
     app.jinja_env.filters['group_files'] = filters.group_files
     app.jinja_env.filters['timesince'] = filters.timesince
+    app.jinja_env.filters['just_updated'] = filters.just_updated
     return app

--- a/submit/filters.py
+++ b/submit/filters.py
@@ -1,9 +1,12 @@
 """Custom Jinja2 filters."""
 
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timedelta
+from pytz import timezone
 from typing import List, Tuple, Optional, Union, Dict, Mapping
-from .domain import FileStatus
+from .domain import FileStatus, UploadStatus
+
+EST = timezone('US/Eastern')
 
 NestedFileTree = Mapping[str, Union[FileStatus, 'NestedFileTree']]
 
@@ -53,7 +56,7 @@ def group_files(files: List[FileStatus]) -> NestedFileTree:
 
 def timesince(timestamp: datetime, default: str = "just now") -> str:
     """Format a :class:`datetime` as a relative duration in plain English."""
-    diff = datetime.utcnow() - timestamp
+    diff = datetime.utcnow().astimezone(EST) - timestamp
     periods = (
         (diff.days / 365, "year", "years"),
         (diff.days / 30, "month", "months"),
@@ -67,3 +70,37 @@ def timesince(timestamp: datetime, default: str = "just now") -> str:
         if period > 1:
             return "%d %s ago" % (period, singular if period == 1 else plural)
     return default
+
+
+def just_updated(status: FileStatus, seconds: int = 2) -> bool:
+    """
+    Filter to determine whether a specific file was just touched.
+
+    Parameters
+    ----------
+    status : :class:`FileStatus`
+        Represents the state of the uploaded file, as conveyed by the file
+        management service.
+    seconds : int
+        Threshold number of seconds for determining whether a file was just
+        touched.
+
+    Returns
+    -------
+    bool
+
+    Examples
+    --------
+
+    .. code-block:: html
+
+       <p>
+           This item
+           {% if item|just_updated %}was just updated
+           {% else %}has been sitting here for a while
+           {% endif %}.
+       </p>
+
+    """
+    now = datetime.utcnow().astimezone(EST)
+    return abs((now - status.modified).seconds) < seconds

--- a/submit/filters.py
+++ b/submit/filters.py
@@ -2,11 +2,9 @@
 
 from collections import OrderedDict
 from datetime import datetime, timedelta
-from pytz import timezone
+from pytz import UTC
 from typing import List, Tuple, Optional, Union, Dict, Mapping
 from .domain import FileStatus, UploadStatus
-
-EST = timezone('US/Eastern')
 
 NestedFileTree = Mapping[str, Union[FileStatus, 'NestedFileTree']]
 
@@ -56,7 +54,7 @@ def group_files(files: List[FileStatus]) -> NestedFileTree:
 
 def timesince(timestamp: datetime, default: str = "just now") -> str:
     """Format a :class:`datetime` as a relative duration in plain English."""
-    diff = datetime.utcnow().astimezone(EST) - timestamp
+    diff = datetime.now(tz=UTC) - timestamp
     periods = (
         (diff.days / 365, "year", "years"),
         (diff.days / 30, "month", "months"),
@@ -102,5 +100,5 @@ def just_updated(status: FileStatus, seconds: int = 2) -> bool:
        </p>
 
     """
-    now = datetime.utcnow().astimezone(EST)
+    now = datetime.now(tz=UTC)
     return abs((now - status.modified).seconds) < seconds

--- a/submit/services/filemanager.py
+++ b/submit/services/filemanager.py
@@ -123,7 +123,6 @@ class FileManagementService(object):
                 file_errors[filename].append(FileError(etype.upper(), message))
             else:
                 non_file_errors.append(FileError(etype.upper(), message))
-
         return UploadStatus(
             started=dateutil.parser.parse(data['start_datetime']),
             completed=dateutil.parser.parse(data['completion_datetime']),

--- a/submit/templates/submit/file_upload.html
+++ b/submit/templates/submit/file_upload.html
@@ -2,7 +2,7 @@
 
 {% macro display_tree(key, item) %}
   {% if key %}
-  <li class="{% if item.errors %}is-warning{% endif %}">
+  <li class="{% if item.errors %}is-warning{% elif item.modified and item|just_updated %}is-success{% endif %}">
   {% endif %}
     {% if item.name %}
     <div class="level" style="margin-bottom: 0px;">
@@ -14,7 +14,7 @@
             <div class="column">{{ item.size|filesizeformat }}</div>
             <div class="column">{{ item.modified|timesince }}</div>
             <div class="column has-text-centered">
-             <a href="{{ url_for('ui.file_delete', submission_id=submission_id) }}?name={{ item.name }}">
+             <a href="{{ url_for('ui.file_delete', submission_id=submission_id) }}?path={{ item.path }}">
                <span class="icon">
                  <i class="fa fa-trash" aria-label="Delete"></i>
                </span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3451594/45637546-ba587000-ba78-11e8-9683-72b2f6c3eb78.png)

This works by comparing the modified timestamp of the file to the current time. If the difference is less than two seconds (configurable), we highlight the file. This way we get a nice visual confirmation when the file is first uploaded, but the green won't stick around on subsequent reloads of the page.

Note that this assumes that timestamps from the file management service are localized. In the current develop branch of FM, this is not the case. Will fix that shortly.