### PR TITLE
ARXIVNG-1175 Support for ancillary uploads

### DIFF
--- a/submit/controllers/tests/test_upload.py
+++ b/submit/controllers/tests/test_upload.py
@@ -48,7 +48,7 @@ class TestUpload(TestCase):
                               domain.Category('astro-ph', 'GA')]
             )
         )
-
+    
     @mock.patch('arxiv.submission.load')
     def test_get_no_upload(self, mock_load):
         """GET request for submission with no upload package."""
@@ -69,6 +69,7 @@ class TestUpload(TestCase):
         self.assertIn('submission', response_data, 'Submission is in response')
         self.assertIn('submission_id', response_data, 'ID is in response')
 
+    @mock.patch(f'{upload.__name__}.UploadForm.Meta.csrf', False)
     @mock.patch(f'{upload.__name__}.alerts', mock.MagicMock())
     @mock.patch(f'{upload.__name__}.filemanager')
     @mock.patch('arxiv.submission.load')
@@ -123,6 +124,7 @@ class TestUpload(TestCase):
         self.assertIn('submission', response_data, 'Submission is in response')
         self.assertIn('submission_id', response_data, 'ID is in response')
 
+    @mock.patch(f'{upload.__name__}.UploadForm.Meta.csrf', False)
     @mock.patch(f'{upload.__name__}.alerts', mock.MagicMock())
     @mock.patch(f'{upload.__name__}.url_for', mock.MagicMock(return_value='/'))
     @mock.patch(f'{upload.__name__}.filemanager')

--- a/submit/controllers/tests/test_upload.py
+++ b/submit/controllers/tests/test_upload.py
@@ -48,7 +48,8 @@ class TestUpload(TestCase):
                               domain.Category('astro-ph', 'GA')]
             )
         )
-    
+
+    @mock.patch(f'{upload.__name__}.UploadForm.Meta.csrf', False)
     @mock.patch('arxiv.submission.load')
     def test_get_no_upload(self, mock_load):
         """GET request for submission with no upload package."""

--- a/submit/controllers/upload.py
+++ b/submit/controllers/upload.py
@@ -17,7 +17,7 @@ from werkzeug.exceptions import InternalServerError, BadRequest,\
     MethodNotAllowed
 from werkzeug.datastructures import FileStorage
 
-from wtforms import BooleanField, widgets, validators, HiddenField
+from wtforms import BooleanField, widgets, validators, HiddenField, FileField
 from flask import url_for, Markup
 
 from arxiv import status
@@ -264,6 +264,14 @@ def delete(method: str, params: MultiDict, session: Session,
         return response_data, status.HTTP_400_BAD_REQUEST, {}
 
 
+class UploadForm(csrf.CSRFForm):
+    """Form for uploading files."""
+
+    file = FileField('Choose a file...',
+                     validators=[validators.DataRequired()])
+    ancillary = BooleanField('Ancillary')
+
+
 class DeleteFileForm(csrf.CSRFForm):
     """Form for deleting individual files."""
 
@@ -356,6 +364,7 @@ def _get_upload(params: MultiDict, session: Session, submission: Submission) \
         'submission': submission,
         'submission_id': submission.submission_id,
         'status': None,
+        'form': UploadForm()
     }
     if submission.source_content is None:
         # Nothing to show; should generate a blank-slate upload screen.
@@ -409,6 +418,14 @@ def _post_new_upload(params: MultiDict, pointer: FileStorage, session: Session,
 
     """
     submitter, client = util.user_and_client_from_session(session)
+
+    # Using a form object provides some extra assurance that this is a legit
+    # request; provides CSRF goodies.
+    params['file'] = pointer
+    form = UploadForm(params)
+    if not form.validate():
+        raise BadRequest('Invalid upload request')
+
     try:
         upload_status = filemanager.upload_package(pointer)
         submission = _update_submission(submission, upload_status, submitter,
@@ -462,8 +479,24 @@ def _post_new_file(params: MultiDict, pointer: FileStorage, session: Session,
     """
     submitter, client = util.user_and_client_from_session(session)
     upload_id = submission.source_content.identifier
+
+    # Using a form object provides some extra assurance that this is a legit
+    # request; provides CSRF goodies.
+    params['file'] = pointer
+    form = UploadForm(params)
+    if not form.validate():
+        logger.error('Invalid upload form: %s', form.errors)
+        alerts.flash_failure(Markup(form.errors[0]))
+        redirect = url_for('ui.file_upload',
+                           submission_id=submission.submission_id)
+        return {}, status.HTTP_303_SEE_OTHER, {'Location': redirect}
+
+    print(form.data)
+    ancillary = bool(form.ancillary.data)
+    print(ancillary)
     try:
-        upload_status = filemanager.add_file(upload_id, pointer)
+        upload_status = filemanager.add_file(upload_id, pointer,
+                                             ancillary=ancillary)
         submission = _update_submission(submission, upload_status, submitter,
                                         client)
         alerts.flash_success(
@@ -520,7 +553,10 @@ def _post_upload(params: MultiDict, files: MultiDict, session: Session,
     try:    # Make sure that we have a file to work with.
         pointer = files['file']
     except KeyError as e:
-        raise BadRequest('No file selected') from e
+        alerts.flash_failure(Markup('Please select a file to upload'))
+        redirect = url_for('ui.file_upload',
+                           submission_id=submission.submission_id)
+        return {}, status.HTTP_303_SEE_OTHER, {'Location': redirect}
 
     if submission.source_content is None:   # New upload package.
         logger.debug('No existing source_content')

--- a/submit/services/filemanager.py
+++ b/submit/services/filemanager.py
@@ -251,7 +251,8 @@ class FileManagementService(object):
         upload_status = self._parse_upload_status(data)
         return upload_status
 
-    def add_file(self, upload_id: int, pointer: FileStorage) -> UploadStatus:
+    def add_file(self, upload_id: int, pointer: FileStorage,
+                 ancillary: bool = False) -> UploadStatus:
         """
         Upload a file or package to an existing upload workspace.
 
@@ -267,6 +268,8 @@ class FileManagementService(object):
             Unique long-lived identifier for the upload.
         pointer : :class:`FileStorage`
             File upload stream from the client.
+        ancillary : bool
+            If ``True``, the file should be added as an ancillary file.
 
         Returns
         -------
@@ -277,7 +280,9 @@ class FileManagementService(object):
 
         """
         files = {'file': (pointer.filename, pointer, pointer.mimetype)}
-        data, headers = self.request('post', f'/{upload_id}', files=files,
+        data, headers = self.request('post', f'/{upload_id}',
+                                     data={'ancillary': ancillary},
+                                     files=files,
                                      expected_code=status.HTTP_201_CREATED)
         upload_status = self._parse_upload_status(data)
         return upload_status
@@ -428,9 +433,10 @@ def upload_package(pointer: FileStorage) -> UploadStatus:
 
 
 @wraps(FileManagementService.add_file)
-def add_file(upload_id: int, pointer: FileStorage) -> UploadStatus:
+def add_file(upload_id: int, pointer: FileStorage, ancillary: bool = False) \
+        -> UploadStatus:
     """See :meth:`FileManagementService.add_file`."""
-    return current_session().add_file(upload_id, pointer)
+    return current_session().add_file(upload_id, pointer, ancillary=ancillary)
 
 
 @wraps(FileManagementService.delete_file)

--- a/submit/templates/submit/file_upload.html
+++ b/submit/templates/submit/file_upload.html
@@ -50,11 +50,12 @@
   <div class="column is-two-thirds-desktop">
     <h2 class="h2">Upload files</h2>
     <form class="form" action="{{ url_for('ui.file_upload', submission_id=submission_id) }}" method="POST" enctype="multipart/form-data">
+      {{ form.csrf_token }}
       <div class="field is-grouped breathe-vertical">
         <div class="control">
           <div class="file has-name">
             <label class="file-label">
-              <input class="file-input" type="file" name="file" id="file">
+              {{ form.file(class="file-input") }}
               <span class="file-cta">
                 <span class="file-icon"><i class="fa fa-upload"></i></span>
                 <span class="file-label">Choose a file…</span>
@@ -65,7 +66,7 @@
         </div>
         <div class="control is-centered-vertically">
           <label class="checkbox">
-            <input type="checkbox"> Ancillary <span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>
+            {{ form.ancillary }} Ancillary <span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>
         </div>
         <div class="control">
           <button type="submit" class="button is-link">Upload</button>


### PR DESCRIPTION
This adds support on the submission UI to upload files as ancillary files. Instead of placing the file in the root of the upload workspace, files should be placed in the ancillary subdirectory (``anc``). This depends on https://github.com/cul-it/arxiv-filemanager/pull/20 and on https://github.com/cul-it/arxiv-submission-ui/pull/31 

![image](https://user-images.githubusercontent.com/3451594/45647080-fac4e780-ba92-11e8-8234-96607e672208.png)
