### PR TITLE
ARXIVNG-1215 ARXIVNG-1270 configure URLs, add help info

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ bleach = "*"
 arxiv-submission-core = "==0.4.2rc3"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
-arxiv-base = "==0.11.1rc5"
+arxiv-base = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ bleach = "*"
 arxiv-submission-core = "==0.4.2rc3"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
-arxiv-base = "*"
+arxiv-base = "==0.11.1rc5"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "07b6d04ae9d600e047ed603cfe9426aed6d96523990eb10df0180c5fdc15ee57"
+            "sha256": "2e8eb56bf74f82a662b4f1085f47e77f076544ced43c7df88740c23404fbceeb"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,10 +23,10 @@
         },
         "arxiv-base": {
             "hashes": [
-                "sha256:0b29db977e15f53215d390da994e29bf39bea03412372bbfa522b71ac85eb4bb"
+                "sha256:e8f8504a4b8ca5a190a3572882cd1cfd544b071cc2deec1e62d90635787da66f"
             ],
             "index": "pypi",
-            "version": "==0.10.1"
+            "version": "==0.11.1rc5"
         },
         "arxiv-submission-core": {
             "hashes": [
@@ -45,17 +45,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0b8b783bc7c85e5a9da310156ae776a26330d290af9fe4687c54d74505eae9de",
-                "sha256:1d26dde21b1b9d6d307578da1ec032977f07004c75fb335b5df1a6a858b66bc2"
+                "sha256:0daae195b2b2f7a7ae6b888ff9dd3f9bf6c339522924f5d73f1ddfc44f07a3f5",
+                "sha256:d97f89a8d1a50377cbb7eca15040e65cd1a97d049e7396757fef00d08db9f285"
             ],
-            "version": "==1.9.38"
+            "version": "==1.9.40"
         },
         "botocore": {
             "hashes": [
-                "sha256:6b092bfe4408111c6d73e7a35484d7bbe2b9143951f3063c4585e5f5f60e383a",
-                "sha256:a9772401d199a7ac4059c5d4a142af37de752065473a086c29cc24960fde9333"
+                "sha256:ad7f7e11aa5927a41e00b398b2c77f49d9f04da3fc509c0378f54973bb8a3421",
+                "sha256:cd01d12bd983c132d53b839097f6d7a9bda0d31d9dd0cb9b86566680efdad24a"
             ],
-            "version": "==1.12.38"
+            "version": "==1.12.40"
         },
         "certifi": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2e8eb56bf74f82a662b4f1085f47e77f076544ced43c7df88740c23404fbceeb"
+            "sha256": "07b6d04ae9d600e047ed603cfe9426aed6d96523990eb10df0180c5fdc15ee57"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,10 +23,10 @@
         },
         "arxiv-base": {
             "hashes": [
-                "sha256:e8f8504a4b8ca5a190a3572882cd1cfd544b071cc2deec1e62d90635787da66f"
+                "sha256:0b29db977e15f53215d390da994e29bf39bea03412372bbfa522b71ac85eb4bb"
             ],
             "index": "pypi",
-            "version": "==0.11.1rc5"
+            "version": "==0.10.1"
         },
         "arxiv-submission-core": {
             "hashes": [
@@ -37,32 +37,32 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:0ee95f6167129859c5dce9b1ca291ebdb5d8cd7e382ca0e237dfd0dad63f63d8",
-                "sha256:24754b9a7d530bf30ce7cbc805bc6cce785660b4a10ff3a43633728438c105ab"
+                "sha256:48d39675b80a75f6d1c3bdbffec791cf0bbbab665cf01e20da701c77de278718",
+                "sha256:73d26f018af5d5adcdabf5c1c974add4361a9c76af215fe32fdec8a6fc5fb9b9"
             ],
             "index": "pypi",
-            "version": "==2.1.4"
+            "version": "==3.0.2"
         },
         "boto3": {
             "hashes": [
-                "sha256:1309725c0223e25c78231af96fe28802e3804b847e58ba451c5d7379eead0614",
-                "sha256:67e89880fceedab0dc922b42206affd19bc52dd8bc113e56e1354b40fff4f4ea"
+                "sha256:0b8b783bc7c85e5a9da310156ae776a26330d290af9fe4687c54d74505eae9de",
+                "sha256:1d26dde21b1b9d6d307578da1ec032977f07004c75fb335b5df1a6a858b66bc2"
             ],
-            "version": "==1.9.13"
+            "version": "==1.9.38"
         },
         "botocore": {
             "hashes": [
-                "sha256:1d437f7d584d4d28e5a28577bc7fc5607a8bdb832d8571d97c45a5510671c01d",
-                "sha256:d3a286aaa63c3388afb49feb36b61992dd37c735462c8b40add79c48bd845bc7"
+                "sha256:6b092bfe4408111c6d73e7a35484d7bbe2b9143951f3063c4585e5f5f60e383a",
+                "sha256:a9772401d199a7ac4059c5d4a142af37de752065473a086c29cc24960fde9333"
             ],
-            "version": "==1.12.13"
+            "version": "==1.12.38"
         },
         "certifi": {
             "hashes": [
-                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
-                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
             ],
-            "version": "==2018.8.24"
+            "version": "==2018.10.15"
         },
         "chardet": {
             "hashes": [
@@ -76,6 +76,7 @@
                 "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==7.0"
         },
         "dataclasses": {
@@ -102,13 +103,6 @@
             "index": "pypi",
             "version": "==1.0.2"
         },
-        "html5lib": {
-            "hashes": [
-                "sha256:20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3",
-                "sha256:66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736"
-            ],
-            "version": "==1.0.1"
-        },
         "idna": {
             "hashes": [
                 "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
@@ -118,9 +112,11 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
             ],
-            "version": "==0.24"
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==1.1.0"
         },
         "jinja2": {
             "hashes": [
@@ -146,9 +142,37 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
+                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
+                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
+                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
+                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
+                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
+                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
+                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
+                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
+                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
+                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
+                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
+                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
+                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
+                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
+                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
+                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
+                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
+                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
+                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
+                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
+                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
+                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
+                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
+                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
+                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
+                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
+                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
-            "version": "==1.0"
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==1.1.0"
         },
         "mysqlclient": {
             "hashes": [
@@ -173,19 +197,19 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
-                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
+                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.7.3"
+            "version": "==2.7.5"
         },
         "pytz": {
             "hashes": [
-                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
-                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
             "index": "pypi",
-            "version": "==2018.5"
+            "version": "==2018.7"
         },
         "pyyaml": {
             "hashes": [
@@ -241,16 +265,17 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:c5951d9ef1d5404ed04bae5a16b60a0779087378928f997a294d1229c6ca4d3e"
+                "sha256:84412de3794acee05630e7788f25e80e81f78eb4837e7b71d0499129f660486a"
             ],
             "index": "pypi",
-            "version": "==1.2.12"
+            "version": "==1.2.13"
         },
         "urllib3": {
             "hashes": [
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "uwsgi": {
@@ -292,10 +317,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
-                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
             ],
-            "version": "==2018.8.24"
+            "version": "==2018.10.15"
         },
         "chardet": {
             "hashes": [
@@ -308,11 +333,9 @@
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
-                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
+                "sha256:0bf8cbbd71adfff0ef1f3a1531e6402d13b7b01ac50a79c97ca15f030dba6306",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
-                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
-                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
                 "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
@@ -335,16 +358,12 @@
                 "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
                 "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
                 "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
-                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
-                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
-                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
                 "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
-                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
+                "sha256:f05a636b4564104120111800021a92e43397bc12a5c72fed7036be8556e0029e",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
             ],
             "index": "pypi",
             "version": "==4.5.1"
@@ -376,6 +395,7 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*'",
             "version": "==4.3.4"
         },
         "lazy-object-proxy": {
@@ -429,11 +449,11 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:00b95bfdc0d5b9aa53c906e56fb91937743f2121d66684db5f947ec5d75f565d",
-                "sha256:6704586b4c2bf7dfa5e87a422be9ca57db622bab65008245759f3d4baeb219dd"
+                "sha256:8e071ec32cc226e948a34bbb3d196eb0fd96f3ac69b6843a5aff9bd4efa14455",
+                "sha256:fb90c804b84cfd8133d3ddfbd630252694d11ccc1eb0166a1b2efb5da37ecab2"
             ],
             "index": "pypi",
-            "version": "==0.630"
+            "version": "==0.641"
         },
         "mypy-extensions": {
             "hashes": [
@@ -451,12 +471,12 @@
         },
         "pydocstyle": {
             "hashes": [
-                "sha256:08a870edc94508264ed90510db466c6357c7192e0e866561d740624a8fc7d90c",
-                "sha256:4d5bcde961107873bae621f3d580c3e35a426d3687ffc6f8fb356f6628da5a97",
-                "sha256:af9fcccb303899b83bec82dc9a1d56c60fc369973223a5e80c3dfa9bdf984405"
+                "sha256:2258f9b0df68b97bf3a6c29003edc5238ff8879f1efb6f1999988d934e432bd8",
+                "sha256:5741c85e408f9e0ddf873611085e819b809fca90b619f5fd7f34bd4959da3dd4",
+                "sha256:ed79d4ec5e92655eccc21eb0c6cf512e69512b4a97d215ace46d17e4990f2039"
             ],
             "index": "pypi",
-            "version": "==2.1.1"
+            "version": "==3.0.0"
         },
         "pylint": {
             "hashes": [
@@ -514,6 +534,7 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
         },
         "urllib3": {
@@ -521,6 +542,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "wrapt": {

--- a/submit/config.py
+++ b/submit/config.py
@@ -73,3 +73,28 @@ FILE_MANAGER_ENDPOINT = os.environ.get(
 FILE_MANAGER_VERIFY = bool(int(os.environ.get('FILE_MANAGER_VERIFY', '1')))
 
 SESSION_COOKIE_NAME = 'submission_ui_session'
+
+EXTERNAL_URL_SCHEME = os.environ.get('EXTERNAL_URL_SCHEME', 'https')
+BASE_SERVER = os.environ.get('BASE_SERVER', 'arxiv.org')
+
+URLS = [
+    ("help_license", "/help/license", BASE_SERVER),
+    ("help_third_party_submission", "/help/third_party_submission", BASE_SERVER),
+    ("help_cross", "/help/cross", BASE_SERVER),
+    ("help_submit", "/help/submit", BASE_SERVER),
+    ("help_ancillary_files", "/help/ancillary_files", BASE_SERVER),
+    ("help_whytex", "/help/faq/whytex", BASE_SERVER),
+    ("help_default_packages", "/help/submit_tex#wegotem", BASE_SERVER),
+    ("help_submit_tex", "/help/submit_tex", BASE_SERVER),
+    ("help_submit_pdf", "/help/submit_pdf", BASE_SERVER),
+    ("help_submit_ps", "/help/submit_ps", BASE_SERVER),
+    ("help_submit_html", "/help/submit_html", BASE_SERVER),
+    ("help_metadata", "/help/prep", BASE_SERVER)
+]
+"""
+URLs for external services, for use with :func:`flask.url_for`.
+This subset of URLs is common only within submit, for now - maybe move to base
+if these pages seem relevant to other services.
+
+For details, see :mod:`arxiv.base.urls`.
+"""

--- a/submit/templates/submit/authorship.html
+++ b/submit/templates/submit/authorship.html
@@ -21,7 +21,8 @@
     <div class="control" style="margin-left: 2.5em; margin-top: -1em">
       <div class="checkbox">
         {{ form.proxy }}
-        {{ form.proxy.label }} <a href="https://arxiv.org/help/third_party_submission" class="help-bubble">
+        {{ form.proxy.label }}
+        <a href="{{ url_for('help_third_party_submission') }}" class="help-bubble">
           <i class="fa fa-question-circle is-info"></i>
           <div class="bubble-text">Third party submissions may have additional requirements. Click for detailed help page.</div></a>
       </div>

--- a/submit/templates/submit/cross_list.html
+++ b/submit/templates/submit/cross_list.html
@@ -38,7 +38,7 @@
     <div class="column is-two-thirds-tablet">
       {% with field = form.category %}
       <label class="label" style="margin-top: 3em">Add a cross-list category
-      <a href="https://arxiv.org/help/cross" class="help-bubble"><i class="fa fa-question-circle is-info"></i><div class="bubble-text">Cross-list suggestions indicate areas of overlapping interest for the submission.</div></a></label>
+      <a href="{{ url_for('help_cross') }}" class="help-bubble"><i class="fa fa-question-circle is-info"></i><div class="bubble-text">Cross-list suggestions indicate areas of overlapping interest for the submission.</div></a></label>
       <div class="field has-addons" style="margin-bottom: 3em">
         <div class="control">
           <div class="select">

--- a/submit/templates/submit/file_upload.html
+++ b/submit/templates/submit/file_upload.html
@@ -89,44 +89,49 @@
       <p class="title is-4 breathe-vertical has-text-centered">
         There's nothing here!
       </p>
+      <div class="message is-link">
+        <div class="message-body">
+          <p><span class="icon has-text-link"><i class="fa fa-exclamation-triangle"></i></span>If this submission was written in TeX, TeX source must be submitted to be compiled by arXiv.
+          PDF documents created from TeX will not be accepted.
+          <a href="{{ url_for('help_whytex') }}">Why?</a></p>
+        </div>
+      </div>
       {% endif %}
     </div>
     <div class="column is-one-third-desktop is-one-quarter-tablet">
       <div class="message is-info">
         <div class="message-body">
-          <div class="is-pulled-left">
-            <span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>
-          </div>
-
-          <p class="has-text-weight-semibold">Accepted File Formats</p>
+          <p class="has-text-weight-semibold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Accepted formats, in order of preference</p>
           <ul>
-            <li>(La)TeX, AMS(La)TeX, PDFLaTeX</li>
-            <li>PDF</li>
-            <li>PostScript</li>
-            <li>HTML</li>
+            <li><a href="{{ url_for('help_submit_tex') }}">(La)TeX, AMS(La)TeX, PDFLaTeX</a></li>
+            <li><a href="{{ url_for('help_submit_pdf') }}">PDF</a></li>
+            <li><a href="{{ url_for('help_submit_ps') }}">PostScript</a></li>
+            <li><a href="{{ url_for('help_submit_html') }}">HTML</a></li>
           </ul>
 
-          <p class="has-text-weight-semibold">Accepted Image Formats</p>
+          <p class="has-text-weight-semibold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Accepted formats for figures</p>
           <ul>
-            <li>PDF or EPS</li>
-            <li>JPG, GIF, PNG</li>
-            <li>SVG?</li>
+            <li>PostScript (PS/EPS)</li>
+            <li>JPG (best for photographs)</li>
+            <li>GIF or PNG</li>
+            <li>PDF figures (only with PDFLaTeX)</li>
           </ul>
 
 
-          <p class="has-text-weight-semibold">Accepted File Properties</p>
+          <p class="has-text-weight-semibold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Accepted file properties</p>
           <ul>
             <li>Names containing a-z A-Z 0-9 . , - _</li>
-            <li>Individual files less than [x]MB</li>
-            <li>Total size less than [x]MB</li>
+            <li>Total compressed package size limit: 6MB</li>
+            <li>Total uncompressed package size limit: 18MB</li>
+            <li>Individual PDF size limit: 15MB</li>
           </ul>
 
 
-          <p class="has-text-weight-semibold">Style and Class Files</p>
+          <p class="has-text-weight-semibold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>TeX style and class files</p>
           <ul>
-            <li><a href="#">Default packages</a></li>
-            <li><a href="#">What to include</a></li>
-            <li><a href="#">Upload FAQ</a></li>
+            <li><a href="help_default_packages">Default packages</a></li>
+            <li><a href="help_submit_tex">What to include</a></li>
+            <!-- <li><a href="#">Upload FAQ</a></li> -->
           </ul>
 
         </div>

--- a/submit/templates/submit/file_upload.html
+++ b/submit/templates/submit/file_upload.html
@@ -66,7 +66,7 @@
         </div>
         <div class="control" style="margin-top: .35em">
           <label class="checkbox">
-            {{ form.ancillary }} Ancillary <a class="icon has-text-link help-bubble" href="https://arxiv.org/help/ancillary_files"><i class="fa fa-info-circle"></i><div class="bubble-text">Ancillary files will be placed in an /anc directory automatically.</div></a>
+            {{ form.ancillary }} Ancillary <a class="icon has-text-link help-bubble" href="{{ url_for('help_ancillary_files') }}"><i class="fa fa-info-circle"></i><div class="bubble-text">Ancillary files will be placed in an /anc directory automatically.</div></a>
         </div>
         <div class="control">
           <button type="submit" class="button is-link">Upload</button>

--- a/submit/templates/submit/license.html
+++ b/submit/templates/submit/license.html
@@ -36,7 +36,7 @@
           <p><span class="icon"><i class="fa fa-info-circle"></i></span>Not sure which license to select?</p>
         </div>
         <div class="message-body">
-          <p>See the <a href="">Discussion of licenses</a> for more information.</p>
+          <p>See the <a href="{{ url_for('help_license') }}">Discussion of licenses</a> for more information.</p>
           <p>If none of these licenses apply, you may be able to indicate your license of choice in the article text.</p>
         </div>
       </div>


### PR DESCRIPTION
Most of ARXIVNG-1270 was done along with ARXIVNG-1259; this PR cleans up some of the leftovers in file upload help text. Imperfect but better.
I chose to place these particular URLs in the submit repo directly because they seemed to apply only within the submission process; happy to move them to base if they are deemed more general.

Screenshot of the new help info for file upload:
![screen shot 2018-11-08 at 4 58 45 pm](https://user-images.githubusercontent.com/17456668/48230249-64b58b00-e378-11e8-98b6-58386bc77841.png)
