### PR TITLE
ARXIVNG-1343 first pass at JREF submission

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ bleach = "*"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.11.1"
-arxiv-submission-core = "==0.5.1rc7"
+arxiv-submission-core = "==0.5.1rc8"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ bleach = "*"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.11.1"
-arxiv-submission-core = "==0.5.1rc6"
+arxiv-submission-core = "==0.5.1rc7"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ bleach = "*"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.11.1"
-arxiv-submission-core = "==0.5.1rc4"
+arxiv-submission-core = "==0.5.1rc6"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,6 @@ bleach = "*"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.11.1"
-"3a3786f" = {path = "./../arxiv-submission-core/core"}
 arxiv-submission-core = "==0.5.1rc4"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -13,10 +13,11 @@ PyYAML = "*"
 pytz = "*"
 SQLAlchemy = "*"
 bleach = "*"
-arxiv-submission-core = "==0.5.1rc1"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.11.1"
+"3a3786f" = {path = "./../arxiv-submission-core/core"}
+arxiv-submission-core = "==0.5.1rc4"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "575d97f25b906c9e64ac452f5a840f5f94ac423aa385bd1ddb22a2f2ba3ab01e"
+            "sha256": "18537e0ba7ef9f90d13987eba7520bfd802cf943dc751b918101c9ec36d55d07"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,9 @@
         ]
     },
     "default": {
+        "3a3786f": {
+            "path": "./../arxiv-submission-core/core"
+        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:c391381cc94b83a9173c383b78b06d5a77d5d124d5686577ba8466e68012fd80"
@@ -30,10 +33,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:896449d89cc181e9dc6f133f64092a8db7112b4fbae25006028d551f627fdbf9"
+                "sha256:e2db2bad186b0dc9f566326f6c5abe0a79422266e1b69627db9495dcf5296a5a"
             ],
             "index": "pypi",
-            "version": "==0.5.1rc1"
+            "version": "==0.5.1rc4"
         },
         "bleach": {
             "hashes": [
@@ -272,6 +275,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "uwsgi": {
@@ -544,6 +548,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "wrapt": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "260cd48a934d2347004e70f9363a752dcc76028c0b137096dacf25e30b40402c"
+            "sha256": "e9bc0d9ef3a85fa7852b4a7df22947ed9ef2192f5863d24c2163c3c6b9cbab05"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -30,10 +30,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:68861f9f2b839582a2f8a1a7380c14dc133fa4c7c9ff5e639138f548b1e2a0cd"
+                "sha256:87b72182ffc8fb5ee204ca800c3928f901a1c4170db6a3f57809b2beaec2fb41"
             ],
             "index": "pypi",
-            "version": "==0.5.1rc6"
+            "version": "==0.5.1rc7"
         },
         "bleach": {
             "hashes": [
@@ -197,6 +197,7 @@
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
                 "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
+            "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
         },
         "pytz": {
@@ -537,7 +538,6 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
-            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
         },
         "urllib3": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ac7a744b1c511a2ba67da2bd675661857072abcfadc02a5bb8edf1f23b63dae8"
+            "sha256": "da5e04f572f0d1185c5cf64bd52e45c43ba75f482920a879782e06f249025d74"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,9 +14,6 @@
         ]
     },
     "default": {
-        "3a3786f": {
-            "path": "./../arxiv-submission-core/core"
-        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:c391381cc94b83a9173c383b78b06d5a77d5d124d5686577ba8466e68012fd80"
@@ -33,10 +30,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:87b72182ffc8fb5ee204ca800c3928f901a1c4170db6a3f57809b2beaec2fb41"
+                "sha256:3273d17c5e0eb040974b487fd78d939d6a7fcedd8dbc157b7263715a97bed688"
             ],
             "index": "pypi",
-            "version": "==0.5.1rc7"
+            "version": "==0.5.1rc8"
         },
         "bleach": {
             "hashes": [
@@ -48,17 +45,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:177e9dd53db5028bb43050da20cc7956287889fc172e5e6275a634e42a10beeb",
-                "sha256:8c63e616b91907037ab19236afbcf0057efb31411faf38b46f4590e634dc17ea"
+                "sha256:40872be3cab0e1078e97aa0cfa8d836841d4e0acf40f5a4e59c6c33eacaea321",
+                "sha256:cc189072a38250d79f61660e83c0af899ff45e9de5f05b0a54f3a8a27b87d153"
             ],
-            "version": "==1.9.50"
+            "version": "==1.9.51"
         },
         "botocore": {
             "hashes": [
-                "sha256:07fae5a2b8cfb5a92c1dbee3f2feb4da7c471bcead7e18ce735babe5f39e270f",
-                "sha256:eeaa190f50ee05a56225ee78c64cb8bf0c3bf090ec605ca6c2f325aa3826a347"
+                "sha256:4209c43f6913470371bda03aea01c933247dc9592421eb1abf1fb9f594f60a35",
+                "sha256:ddbd84e0c8f9bd29f9f67e10089df87089d0f10a8a45e156c7d2def7707d0113"
             ],
-            "version": "==1.12.50"
+            "version": "==1.12.51"
         },
         "certifi": {
             "hashes": [
@@ -275,7 +272,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "uwsgi": {
@@ -310,10 +306,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:292fa429e69d60e4161e7612cb7cc8fa3609e2e309f80c224d93a76d5e7b58be",
-                "sha256:c7013d119ec95eb626f7a2011f0b63d0c9a095df9ad06d8507b37084eada1a8d"
+                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
+                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
             ],
-            "version": "==2.0.4"
+            "version": "==2.1.0"
         },
         "certifi": {
             "hashes": [
@@ -487,11 +483,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:1d6d3622c94b4887115fe5204982eee66fdd8a951cf98635ee5caee6ec98c3ec",
-                "sha256:31142f764d2a7cd41df5196f9933b12b7ee55e73ef12204b648ad7e556c119fb"
+                "sha256:51f5a52bd31cb2db5b83ff37e3e902460eaa5591dea2739ba5d10d13ec5c5350",
+                "sha256:fe49f9ada5c8999344ac3a37541e329eaff11d014460065c4128fc94cf5cf140"
             ],
             "index": "pypi",
-            "version": "==2.1.1"
+            "version": "==2.2.0"
         },
         "requests": {
             "hashes": [
@@ -549,7 +545,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "wrapt": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e9bc0d9ef3a85fa7852b4a7df22947ed9ef2192f5863d24c2163c3c6b9cbab05"
+            "sha256": "ac7a744b1c511a2ba67da2bd675661857072abcfadc02a5bb8edf1f23b63dae8"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,9 @@
         ]
     },
     "default": {
+        "3a3786f": {
+            "path": "./../arxiv-submission-core/core"
+        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:c391381cc94b83a9173c383b78b06d5a77d5d124d5686577ba8466e68012fd80"
@@ -45,17 +48,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:8bc0c3333d4858b26a8f84b231479b92d4bc965ae75b9bfdb0d4dfa7164f2317",
-                "sha256:b8a6d9beff31492bd135709d5fbfbe902931c2a6708c4ccbe01f704924f182b8"
+                "sha256:177e9dd53db5028bb43050da20cc7956287889fc172e5e6275a634e42a10beeb",
+                "sha256:8c63e616b91907037ab19236afbcf0057efb31411faf38b46f4590e634dc17ea"
             ],
-            "version": "==1.9.48"
+            "version": "==1.9.50"
         },
         "botocore": {
             "hashes": [
-                "sha256:7140e51ab0a7aa3b7fa9cf5fefa663e0cd097098fcbd51b12ff8884c8d967754",
-                "sha256:8f290040128194454d25a39061ffcb089914c2e1dd619b621308cb59c339df4f"
+                "sha256:07fae5a2b8cfb5a92c1dbee3f2feb4da7c471bcead7e18ce735babe5f39e270f",
+                "sha256:eeaa190f50ee05a56225ee78c64cb8bf0c3bf090ec605ca6c2f325aa3826a347"
             ],
-            "version": "==1.12.48"
+            "version": "==1.12.50"
         },
         "certifi": {
             "hashes": [
@@ -538,6 +541,7 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
         },
         "urllib3": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "18537e0ba7ef9f90d13987eba7520bfd802cf943dc751b918101c9ec36d55d07"
+            "sha256": "260cd48a934d2347004e70f9363a752dcc76028c0b137096dacf25e30b40402c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,9 +14,6 @@
         ]
     },
     "default": {
-        "3a3786f": {
-            "path": "./../arxiv-submission-core/core"
-        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:c391381cc94b83a9173c383b78b06d5a77d5d124d5686577ba8466e68012fd80"
@@ -33,10 +30,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:e2db2bad186b0dc9f566326f6c5abe0a79422266e1b69627db9495dcf5296a5a"
+                "sha256:68861f9f2b839582a2f8a1a7380c14dc133fa4c7c9ff5e639138f548b1e2a0cd"
             ],
             "index": "pypi",
-            "version": "==0.5.1rc4"
+            "version": "==0.5.1rc6"
         },
         "bleach": {
             "hashes": [
@@ -200,7 +197,6 @@
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
                 "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
-            "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
         },
         "pytz": {
@@ -541,6 +537,7 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
         },
         "urllib3": {

--- a/submit/controllers/__init__.py
+++ b/submit/controllers/__init__.py
@@ -1,11 +1,32 @@
 """Request controllers for the submission UI."""
 
+from typing import Tuple, Dict, Any
+
+from arxiv import status
+from arxiv.users.domain import Session
+
 from .upload import upload_files
 from .upload import delete as delete_file
 from .upload import delete_all as delete_all_files
 
+from ..util import load_submission
 from . import create, verify_user, authorship, license, policy, \
-    classification, metadata
+    classification, metadata, util
 
 __all__ = ('verify_user', 'authorship', 'license', 'policy', 'classification',
            'metadata', 'create')
+
+Response = Tuple[Dict[str, Any], int, Dict[str, Any]]
+
+
+def submission_status(session: Session, submission_id: int) -> Response:
+    user, client = util.user_and_client_from_session(session)
+
+    # Will raise NotFound if there is no such submission.
+    submission, submission_events = load_submission(submission_id)
+    response_data = {
+        'submission': submission,
+        'submission_id': submission_id,
+        'events': submission_events
+    }
+    return response_data, status.HTTP_200_OK, {}

--- a/submit/controllers/__init__.py
+++ b/submit/controllers/__init__.py
@@ -11,10 +11,10 @@ from .upload import delete_all as delete_all_files
 
 from ..util import load_submission
 from . import create, verify_user, authorship, license, policy, \
-    classification, metadata, util
+    classification, metadata, util, jref
 
 __all__ = ('verify_user', 'authorship', 'license', 'policy', 'classification',
-           'metadata', 'create')
+           'metadata', 'create', 'jref')
 
 Response = Tuple[Dict[str, Any], int, Dict[str, Any]]
 

--- a/submit/controllers/authorship.py
+++ b/submit/controllers/authorship.py
@@ -52,7 +52,7 @@ def authorship(method: str, params: MultiDict, session: Session,
     user, client = util.user_and_client_from_session(session)
 
     # Will raise NotFound if there is no such submission.
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
 
     # The form should be prepopulated based on the current state of the
     # submission.
@@ -63,7 +63,6 @@ def authorship(method: str, params: MultiDict, session: Session,
     response_data = {
         'submission_id': submission_id,
         'form': form,
-
     }
 
     if method == 'POST':

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -105,7 +105,7 @@ def classification(method: str, params: MultiDict, session: Session,
     submitter, client = util.user_and_client_from_session(session)
 
     # Will raise NotFound if there is no such submission.
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
 
     # The form should be prepopulated based on the current state of the
     # submission.
@@ -170,7 +170,7 @@ def cross_list(method: str, params: MultiDict, session: Session,
     submitter, client = util.user_and_client_from_session(session)
 
     # Will raise NotFound if there is no such submission.
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
 
     # We need forms for existing secondaries, to generate removal requests.
     formset = _formset_from_submission(submission)

--- a/submit/controllers/jref.py
+++ b/submit/controllers/jref.py
@@ -87,13 +87,17 @@ def jref(method: str, params: MultiDict, session: Session,
         params = MultiDict({
             'doi': submission.metadata.doi,
             'journal_ref': submission.metadata.journal_ref,
-            'report_num': submission.metadata.report_num,
+            'report_num': submission.metadata.report_num
         })
 
     form = JREFForm(params)
     form.submission = submission
     form.creator = submitter
-    response_data = {'submission_id': submission_id, 'form': form}
+    response_data = {
+        'submission_id': submission_id,
+        'submission': submission,
+        'form': form
+    }
 
     if method == 'POST':
         if not form.validate():

--- a/submit/controllers/jref.py
+++ b/submit/controllers/jref.py
@@ -5,15 +5,120 @@ from typing import Tuple, Dict, Any, Optional
 from werkzeug import MultiDict
 from werkzeug.exceptions import InternalServerError, NotFound
 
-from flask import url_for
-from wtforms import BooleanField, RadioField
+from flask import url_for, Markup
+from wtforms.fields import TextField, TextAreaField, Field
 from wtforms.validators import InputRequired, ValidationError, optional
 
 from arxiv import status
-from arxiv.base import logging
+from arxiv.base import logging, alerts
 from arxiv.forms import csrf
 from arxiv.users.domain import Session
 import arxiv.submission as events
 
 from ..util import load_submission
 from . import util
+
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
+
+Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
+
+
+class JREFForm(csrf.CSRFForm, util.FieldMixin, util.SubmissionMixin):
+    """Set DOI and/or journal reference on a published submission."""
+
+    doi = TextField('DOI', validators=[optional()],
+                    description="Full DOI of the version of record.")
+    journal_ref = TextField('Journal reference', validators=[optional()],
+                            description=(
+                                "See <a href='https://arxiv.org/help/jref'>"
+                                "the arXiv help pages</a> for details."
+                            ))
+    report_num = TextField('Report number', validators=[optional()],
+                           description=(
+                               "See <a href='https://arxiv.org/help/jref'>"
+                               "the arXiv help pages</a> for details."
+                           ))
+
+    def validate_doi(form: csrf.CSRFForm, field: Field) -> None:
+        """Validate DOI input using core events."""
+        if field.data == form.submission.metadata.doi:     # Nothing to do.
+            return
+        if field.data:
+            form._validate_event(events.SetDOI, doi=field.data)
+
+    def validate_journal_ref(form: csrf.CSRFForm, field: Field) -> None:
+        """Validate journal reference input using core events."""
+        if field.data == form.submission.metadata.journal_ref:
+            return
+        if field.data:
+            form._validate_event(events.SetJournalReference,
+                                 journal_ref=field.data)
+
+
+def jref(method: str, params: MultiDict, session: Session,
+         submission_id: int) -> Response:
+    """Set journal reference metadata on a published submission."""
+    submitter, client = util.user_and_client_from_session(session)
+    logger.debug(f'method: {method}, submission: {submission_id}. {params}')
+
+    # Will raise NotFound if there is no such submission.
+    submission, submission_events = load_submission(submission_id)
+
+    # The submission must be published for this to be a real JREF submission.
+    if not submission.published:
+        alerts.flash_failure(Markup("Submission must first be published. See "
+                                    "<a href='https://arxiv.org/help/jref'>"
+                                    "the arXiv help pages</a> for details."))
+        status_url = url_for('ui.submission_status',
+                             submission_id=submission_id)
+        return {}, status.HTTP_303_SEE_OTHER, {'Location': status_url}
+
+    # The form should be prepopulated based on the current state of the
+    # submission.
+    if method == 'GET':
+        params = MultiDict({
+            'doi': submission.metadata.doi,
+            'journal_ref': submission.metadata.journal_ref,
+            'report_num': submission.metadata.report_num,
+        })
+
+    form = JREFForm(params)
+    form.submission = submission
+    form.creator = submitter
+    response_data = {'submission_id': submission_id, 'form': form}
+
+    if method == 'POST':
+        if not form.validate():
+            logger.debug('Invalid form data; return bad request')
+            return response_data, status.HTTP_400_BAD_REQUEST, {}
+
+        logger.debug('Form is valid, with data: %s', str(form.data))
+
+        # form.events get set by the SubmissionMixin during validation.
+        # TODO: that's kind of indirect.
+        if form.events:   # Metadata has changed.
+            try:
+                # Save the events created during form validation.
+                submission, stack = events.save(*form.events,
+                                                submission_id=submission_id)
+            except events.exceptions.InvalidStack as e:
+                logger.error('Could not add JREF: %s', str(e))
+                form.errors     # Causes the form to initialize errors.
+                form._errors['events'] = [
+                    ie.message for ie in e.event_exceptions
+                ]
+                logger.debug('InvalidStack; return bad request')
+                return response_data, status.HTTP_400_BAD_REQUEST, {}
+            except events.exceptions.SaveError as e:
+                logger.error('Could not save metadata event')
+                raise InternalServerError(
+                    'There was a problem saving this operation'
+                ) from e
+
+            # Success! Send user back to the submission page.
+            alerts.flash_success("Journal reference updated")
+            status_url = url_for('ui.submission_status',
+                                 submission_id=submission_id)
+            return {}, status.HTTP_303_SEE_OTHER, {'Location': status_url}
+    logger.debug('Nothing to do, return 200')
+    return response_data, status.HTTP_200_OK, {}

--- a/submit/controllers/jref.py
+++ b/submit/controllers/jref.py
@@ -1,0 +1,19 @@
+"""Controller for JREF submissions."""
+
+from typing import Tuple, Dict, Any, Optional
+
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError, NotFound
+
+from flask import url_for
+from wtforms import BooleanField, RadioField
+from wtforms.validators import InputRequired, ValidationError, optional
+
+from arxiv import status
+from arxiv.base import logging
+from arxiv.forms import csrf
+from arxiv.users.domain import Session
+import arxiv.submission as events
+
+from ..util import load_submission
+from . import util

--- a/submit/controllers/jref.py
+++ b/submit/controllers/jref.py
@@ -54,6 +54,14 @@ class JREFForm(csrf.CSRFForm, util.FieldMixin, util.SubmissionMixin):
             form._validate_event(events.SetJournalReference,
                                  journal_ref=field.data)
 
+    def validate_report_num(form: csrf.CSRFForm, field: Field) -> None:
+        """Validate report number input using core events."""
+        if field.data == form.submission.metadata.report_num:
+            return
+        if field.data:
+            form._validate_event(events.SetReportNumber,
+                                 report_num=field.data)
+
 
 def jref(method: str, params: MultiDict, session: Session,
          submission_id: int) -> Response:

--- a/submit/controllers/license.py
+++ b/submit/controllers/license.py
@@ -44,7 +44,7 @@ def license(method: str, params: MultiDict, session: Session,
     logger.debug(f'method: {method}, submission: {submission_id}. {params}')
 
     # Will raise NotFound if there is no such submission.
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
 
     # The form should be prepopulated based on the current state of the
     # submission.

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -161,7 +161,7 @@ def metadata(method: str, params: MultiDict, session: Session,
     logger.debug(f'method: {method}, submission: {submission_id}. {params}')
 
     # Will raise NotFound if there is no such submission.
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
     # The form should be prepopulated based on the current state of the
     # submission.
     if method == 'GET':
@@ -219,7 +219,7 @@ def optional(method: str, params: MultiDict, session: Session,
     logger.debug(f'method: {method}, submission: {submission_id}. {params}')
 
     # Will raise NotFound if there is no such submission.
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
     # The form should be prepopulated based on the current state of the
     # submission.
     if method == 'GET':

--- a/submit/controllers/policy.py
+++ b/submit/controllers/policy.py
@@ -32,7 +32,7 @@ def policy(method: str, params: MultiDict, session: Session,
     submitter, client = util.user_and_client_from_session(session)
 
     logger.debug(f'method: {method}, submission: {submission_id}. {params}')
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
 
     if method == 'GET' and submission.submitter_accepts_policy:
         params['policy'] = 'true'

--- a/submit/controllers/tests/test_jref.py
+++ b/submit/controllers/tests/test_jref.py
@@ -1,0 +1,144 @@
+"""Tests for :mod:`submit.controllers.jref`."""
+
+from unittest import TestCase, mock
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError, NotFound
+from wtforms import Form
+from arxiv import status
+import arxiv.submission as events
+from submit.controllers import jref
+
+from pytz import timezone
+from datetime import timedelta, datetime
+from arxiv.users import auth, domain
+
+
+def mock_save(*events, submission_id=None):
+    for event in events:
+        event.submission_id = submission_id
+    return mock.MagicMock(submission_id=submission_id), events
+
+
+class TestJREFSubmission(TestCase):
+    """Test behavior of :func:`.jref` controller."""
+
+    def setUp(self):
+        """Create an authenticated session."""
+        # Specify the validity period for the session.
+        start = datetime.now(tz=timezone('US/Eastern'))
+        end = start + timedelta(seconds=36000)
+        self.session = domain.Session(
+            session_id='123-session-abc',
+            start_time=start, end_time=end,
+            user=domain.User(
+                user_id='235678',
+                email='foo@foo.com',
+                username='foouser',
+                name=domain.UserFullName("Jane", "Bloggs", "III"),
+                profile=domain.UserProfile(
+                    affiliation="FSU",
+                    rank=3,
+                    country="de",
+                    default_category=domain.Category('astro-ph', 'GA'),
+                    submission_groups=['grp_physics']
+                )
+            ),
+            authorizations=domain.Authorizations(
+                scopes=[auth.scopes.CREATE_SUBMISSION,
+                        auth.scopes.EDIT_SUBMISSION,
+                        auth.scopes.VIEW_SUBMISSION],
+                endorsements=[domain.Category('astro-ph', 'CO'),
+                              domain.Category('astro-ph', 'GA')]
+            )
+        )
+
+    @mock.patch(f'{jref.__name__}.alerts')
+    @mock.patch(f'{jref.__name__}.url_for')
+    @mock.patch(f'{jref.__name__}.JREFForm.Meta.csrf', False)
+    @mock.patch('arxiv.submission.load')
+    def test_GET_with_unpublished(self, mock_load, mock_url_for, mock_alerts):
+        """GET request for an unpublished submission."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id, published=False), []
+        )
+        mock_url_for.return_value = "/url/for/submission/status"
+        data, code, headers = jref.jref('GET', MultiDict(), self.session,
+                                        submission_id)
+        self.assertEqual(code, status.HTTP_303_SEE_OTHER,
+                         "Returns 303 See Other")
+        self.assertIn('Location', headers, "Returns Location header")
+        self.assertTrue(
+            mock_url_for.called_with('ui.submission_status', submission_id=2),
+            "Gets the URL for the submission status page"
+        )
+        self.assertEqual(headers['Location'], "/url/for/submission/status",
+                         "Returns the URL for the submission status page")
+        self.assertEqual(mock_alerts.flash_failure.call_count, 1,
+                         "An informative message is shown to the user")
+
+    @mock.patch(f'{jref.__name__}.alerts')
+    @mock.patch(f'{jref.__name__}.url_for')
+    @mock.patch(f'{jref.__name__}.JREFForm.Meta.csrf', False)
+    @mock.patch('arxiv.submission.load')
+    def test_POST_with_unpublished(self, mock_load, mock_url_for, mock_alerts):
+        """POST request for an unpublished submission."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id, published=False), []
+        )
+        mock_url_for.return_value = "/url/for/submission/status"
+        request_data = MultiDict({'doi': '10.1000/182'})    # Valid.
+        data, code, headers = jref.jref('POST', request_data, self.session,
+                                        submission_id)
+        self.assertEqual(code, status.HTTP_303_SEE_OTHER,
+                         "Returns 303 See Other")
+        self.assertIn('Location', headers, "Returns Location header")
+        self.assertTrue(
+            mock_url_for.called_with('ui.submission_status', submission_id=2),
+            "Gets the URL for the submission status page"
+        )
+        self.assertEqual(headers['Location'], "/url/for/submission/status",
+                         "Returns the URL for the submission status page")
+        self.assertEqual(mock_alerts.flash_failure.call_count, 1,
+                         "An informative message is shown to the user")
+
+    @mock.patch(f'{jref.__name__}.JREFForm.Meta.csrf', False)
+    @mock.patch('arxiv.submission.load')
+    def test_GET_with_published(self, mock_load):
+        """GET request for a published submission."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id, published=True), []
+        )
+        data, code, headers = jref.jref('GET', MultiDict(), self.session,
+                                        submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertIn('form', data, "Returns form in response data")
+
+    @mock.patch(f'{jref.__name__}.alerts')
+    @mock.patch(f'{jref.__name__}.url_for')
+    @mock.patch(f'{jref.__name__}.JREFForm.Meta.csrf', False)
+    @mock.patch('arxiv.submission.load')
+    @mock.patch('arxiv.submission.save', mock_save)
+    def test_POST_with_published(self, mock_load, mock_url_for, mock_alerts):
+        """POST request for a published submission."""
+        submission_id = 2
+        mock_load.return_value = (
+            mock.MagicMock(submission_id=submission_id, published=True), []
+        )
+        mock_url_for.return_value = "/url/for/submission/status"
+        request_data = MultiDict({'doi': '10.1000/182'})
+        data, code, headers = jref.jref('POST', request_data, self.session,
+                                        submission_id)
+        self.assertEqual(code, status.HTTP_303_SEE_OTHER,
+                         "Returns 303 See Other")
+        self.assertIn('Location', headers, "Returns Location header")
+        self.assertTrue(
+            mock_url_for.called_with('ui.submission_status', submission_id=2),
+            "Gets the URL for the submission status page"
+        )
+        self.assertEqual(headers['Location'], "/url/for/submission/status",
+                         "Returns the URL for the submission status page")
+        self.assertEqual(mock_alerts.flash_success.call_count, 1,
+                         "An informative message is shown to the user")

--- a/submit/controllers/tests/test_jref.py
+++ b/submit/controllers/tests/test_jref.py
@@ -131,6 +131,11 @@ class TestJREFSubmission(TestCase):
         request_data = MultiDict({'doi': '10.1000/182'})
         data, code, headers = jref.jref('POST', request_data, self.session,
                                         submission_id)
+        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+
+        request_data['confirmed'] = True
+        data, code, headers = jref.jref('POST', request_data, self.session,
+                                        submission_id)
         self.assertEqual(code, status.HTTP_303_SEE_OTHER,
                          "Returns 303 See Other")
         self.assertIn('Location', headers, "Returns Location header")

--- a/submit/controllers/upload.py
+++ b/submit/controllers/upload.py
@@ -110,7 +110,7 @@ def upload_files(method: str, params: MultiDict, files: MultiDict,
 
     """
     logger.debug('%s upload request for submission %i', method, submission_id)
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
     logger.debug('Loaded submission with ID %i', submission.submission_id)
 
     filemanager.set_auth_token(token)
@@ -156,7 +156,7 @@ def delete_all(method: str, params: MultiDict, session: Session,
 
     """
     logger.debug('%s delete all files with params %s', method, params)
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
     upload_id = submission.source_content.identifier
     response_data = {
         'submission': submission,
@@ -238,7 +238,7 @@ def delete(method: str, params: MultiDict, session: Session,
         applicable.
     """
     logger.debug('%s delete with params %s', method, params)
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
     upload_id = submission.source_content.identifier
     response_data = {
         'submission': submission,

--- a/submit/controllers/verify_user.py
+++ b/submit/controllers/verify_user.py
@@ -40,7 +40,7 @@ def verify_user(method: str, params: MultiDict, session: Session,
 
     if submission_id:
         # Will raise NotFound if there is no such submission.
-        submission = load_submission(submission_id)
+        submission, submission_events = load_submission(submission_id)
 
     # Initialize the form with the current state of the submission.
     if method == 'GET':

--- a/submit/routes/auth.py
+++ b/submit/routes/auth.py
@@ -8,5 +8,5 @@ from submit.util import load_submission
 # will need to be updated.
 def can_edit_submission(session: Session, submission_id: str, **kw) -> bool:
     """Check whether the user has privileges to edit a submission."""
-    submission = load_submission(submission_id)
+    submission, submission_events = load_submission(submission_id)
     return submission.owner.native_id == session.user.user_id

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -395,3 +395,26 @@ def confirm_delete(submission_id: int) -> Response:
     code = status.HTTP_200_OK
     response = make_response(rendered, code)
     return response
+
+
+# Other workflows.
+
+
+@blueprint.route('/<int:submission_id>/jref', methods=['GET', 'POST'])
+@auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION,
+                        authorizer=can_edit_submission)
+def jref(submission_id: Optional[int] = None) -> Response:
+    """Render the submit start page."""
+    request_data = MultiDict(request.form.items(multi=True))
+    data, code, headers = controllers.jref.jref(
+        request.method,
+        request_data,
+        request.session,
+        submission_id
+    )
+    if code in [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST]:
+        rendered = render_template("submit/jref.html",
+                                   pagetitle='Add journal reference',
+                                   **data)
+        return make_response(rendered, code)
+    return Response(response=data, status=code, headers=headers)

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -42,6 +42,19 @@ def create_submission():
     raise InternalServerError('Something went wrong')
 
 
+@blueprint.route('/<int:submission_id>', methods=['GET'])
+def submission_status(submission_id: int) -> Response:
+    """Display the current state of the submission."""
+    data, code, headers = controllers.submission_status(
+        request.session,
+        submission_id
+    )
+    rendered = render_template("submit/status.html",
+                               pagetitle='Submission status',
+                               **data)
+    return make_response(rendered, code)
+
+
 @blueprint.route('/<int:submission_id>/verify_user',
                  endpoint=SubmissionStage.Stages.VERIFY_USER.value,
                  methods=['GET', 'POST'])

--- a/submit/routes/util.py
+++ b/submit/routes/util.py
@@ -28,7 +28,8 @@ def flow_control(this_stage: SubmissionStage.Stages,
         def wrapper(submission_id: str) -> Response:
             """Update the redirect to the next, previous, or exit page."""
             action = request.form.get('action')
-            stage = SubmissionStage(submission=load_submission(submission_id))
+            submission, _ = load_submission(submission_id)
+            stage = SubmissionStage(submission=submission)
 
             # Set the stage handled by this endpoint.
             g = get_application_global()

--- a/submit/templates/submit/base.html
+++ b/submit/templates/submit/base.html
@@ -8,7 +8,7 @@
 {% endblock addl_head %}
 
 {% block content %}
-{% if submission_id %}
+{% if submission_id and stage %}
   {{ submit_macros.progress_bar(submission_id, stage, this_stage) }}
 {% endif %}
   <h1 class="title">Submit an Article: {% block title %}{% endblock title %}</h1>

--- a/submit/templates/submit/jref.html
+++ b/submit/templates/submit/jref.html
@@ -1,0 +1,98 @@
+{%- extends "base/base.html" %}
+
+{% import "submit/submit_macros.html" as submit_macros %}
+
+{% block addl_head %}
+ <link rel="stylesheet" href="{{ url_for('static', filename='css/submit.css')}}" />
+ <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
+{% endblock addl_head %}
+
+{% block content %}
+  <h1 class="title">Update journal reference</h1>
+  <content>
+
+
+    <form method="POST" action="{{ url_for('ui.jref', submission_id=submission_id) }}">
+      {{ form.csrf_token }}
+      {% with field = form.doi %}
+      <div class="field is-short-field">
+        <div class="control">
+          <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+          {% if field.errors %}
+            <div class="help is-danger">
+              {% for error in field.errors %}
+                  {{ error }}
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if field.description %}
+          <p class="help has-text-grey is-marginless">
+            {{ field.description|safe }}
+          </p>
+          {% endif %}
+          {% if field.errors %}
+            {{ field(class="input is-danger")|safe }}
+          {% else %}
+            {{ field(class="input")|safe }}
+          {% endif %}
+        </div>
+      </div>
+      {% endwith %}
+
+      {% with field = form.journal_ref %}
+      <div class="field is-short-field">
+        <div class="control">
+          <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+          {% if field.errors %}
+            <div class="help is-danger">
+              {% for error in field.errors %}
+                  {{ error }}
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if field.description %}
+          <p class="help has-text-grey is-marginless">
+            {{ field.description|safe }}
+          </p>
+          {% endif %}
+          {% if field.errors %}
+            {{ field(class="input is-danger")|safe }}
+          {% else %}
+            {{ field(class="input")|safe }}
+          {% endif %}
+        </div>
+      </div>
+      {% endwith %}
+
+      {% with field = form.report_num %}
+      <div class="field is-short-field">
+        <div class="control">
+          <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+          {% if field.errors %}
+            <div class="help is-danger">
+              {% for error in field.errors %}
+                  {{ error }}
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if field.description %}
+          <p class="help has-text-grey is-marginless">
+            {{ field.description|safe }}
+          </p>
+          {% endif %}
+          {% if field.errors %}
+            {{ field(class="input is-danger")|safe }}
+          {% else %}
+            {{ field(class="input")|safe }}
+          {% endif %}
+        </div>
+      </div>
+      {% endwith %}
+
+      <div class="buttons submit-nav" role="navigation">
+          <button name="cancel" class="button has-text-grey is-light is-outlined" style="border:0" value="cancel" aria-label="Cancel submission" title="Cancel submission"><span class="icon"><i class="fa fa-trash fa-lg"></i></button>
+          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Submit</button>
+      </div>
+    </form>
+  </content>
+{% endblock content %}

--- a/submit/templates/submit/jref.html
+++ b/submit/templates/submit/jref.html
@@ -16,91 +16,120 @@
     Additionally, a report number field is provided for institutional report
     numbers.
   </p>
+  {% if require_confirmation and not confirmed %}
+  <div class="notification is-info">
+    Please review the preview of your paper's abstract page, and confirm that
+    you with to proceed. You can continue to make changes until you are
+    satisfied with the result.
+  </div>
+  {% endif %}
   <h2>arXiv:{{ submission.arxiv_id }}v{{ submission.version }} {{ submission.metadata.title }}</h2>
-  <p>{{ submission.metadata.authors_disay }}</p>
   <content>
-
-
     <form method="POST" action="{{ url_for('ui.jref', submission_id=submission_id) }}">
-      {{ form.csrf_token }}
-      {% with field = form.doi %}
-      <div class="field is-short-field">
-        <div class="control">
-          <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-          {% if field.errors %}
-            <div class="help is-danger">
-              {% for error in field.errors %}
-                  {{ error }}
-              {% endfor %}
+      <div class="columns">
+        <div class="column">
+          {{ form.csrf_token }}
+          {% with field = form.doi %}
+          <div class="field is-short-field">
+            <div class="control">
+              <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+              {% if field.errors %}
+                <div class="help is-danger">
+                  {% for error in field.errors %}
+                      {{ error }}
+                  {% endfor %}
+                </div>
+              {% endif %}
+              {% if field.description %}
+              <p class="help has-text-grey is-marginless">
+                {{ field.description|safe }}
+              </p>
+              {% endif %}
+              {% if field.errors %}
+                {{ field(class="input is-danger")|safe }}
+              {% else %}
+                {{ field(class="input")|safe }}
+              {% endif %}
             </div>
-          {% endif %}
-          {% if field.description %}
-          <p class="help has-text-grey is-marginless">
-            {{ field.description|safe }}
-          </p>
-          {% endif %}
-          {% if field.errors %}
-            {{ field(class="input is-danger")|safe }}
-          {% else %}
-            {{ field(class="input")|safe }}
+          </div>
+          {% endwith %}
+
+          {% with field = form.journal_ref %}
+          <div class="field is-short-field">
+            <div class="control">
+              <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+              {% if field.errors %}
+                <div class="help is-danger">
+                  {% for error in field.errors %}
+                      {{ error }}
+                  {% endfor %}
+                </div>
+              {% endif %}
+              {% if field.description %}
+              <p class="help has-text-grey is-marginless">
+                {{ field.description|safe }}
+              </p>
+              {% endif %}
+              {% if field.errors %}
+                {{ field(class="input is-danger")|safe }}
+              {% else %}
+                {{ field(class="input")|safe }}
+              {% endif %}
+            </div>
+          </div>
+          {% endwith %}
+
+          {% with field = form.report_num %}
+          <div class="field is-short-field">
+            <div class="control">
+              <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+              {% if field.errors %}
+                <div class="help is-danger">
+                  {% for error in field.errors %}
+                      {{ error }}
+                  {% endfor %}
+                </div>
+              {% endif %}
+              {% if field.description %}
+              <p class="help has-text-grey is-marginless">
+                {{ field.description|safe }}
+              </p>
+              {% endif %}
+              {% if field.errors %}
+                {{ field(class="input is-danger")|safe }}
+              {% else %}
+                {{ field(class="input")|safe }}
+              {% endif %}
+            </div>
+          </div>
+          {% endwith %}
+        </div>
+        <div class="column">
+          {% if require_confirmation and not confirmed %}
+          <div class="box">
+            <p>The abs-page preview goes here, and shows these values in context.</p>
+            <dl>
+              <dt>DOI</dt>
+              <dd>{{ form.doi.data }}</dd>
+
+              <dt>Journal Reference</dt>
+              <dd>{{ form.journal_ref.data }}</dd>
+
+              <dt>Report Number</dt>
+              <dd>{{ form.report_num.data }}</dd>
+            </dl>
+          </div>
           {% endif %}
         </div>
       </div>
-      {% endwith %}
-
-      {% with field = form.journal_ref %}
-      <div class="field is-short-field">
-        <div class="control">
-          <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-          {% if field.errors %}
-            <div class="help is-danger">
-              {% for error in field.errors %}
-                  {{ error }}
-              {% endfor %}
-            </div>
-          {% endif %}
-          {% if field.description %}
-          <p class="help has-text-grey is-marginless">
-            {{ field.description|safe }}
-          </p>
-          {% endif %}
-          {% if field.errors %}
-            {{ field(class="input is-danger")|safe }}
-          {% else %}
-            {{ field(class="input")|safe }}
-          {% endif %}
-        </div>
-      </div>
-      {% endwith %}
-
-      {% with field = form.report_num %}
-      <div class="field is-short-field">
-        <div class="control">
-          <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-          {% if field.errors %}
-            <div class="help is-danger">
-              {% for error in field.errors %}
-                  {{ error }}
-              {% endfor %}
-            </div>
-          {% endif %}
-          {% if field.description %}
-          <p class="help has-text-grey is-marginless">
-            {{ field.description|safe }}
-          </p>
-          {% endif %}
-          {% if field.errors %}
-            {{ field(class="input is-danger")|safe }}
-          {% else %}
-            {{ field(class="input")|safe }}
-          {% endif %}
-        </div>
-      </div>
-      {% endwith %}
-
       <div class="buttons submit-nav" role="navigation">
           <a href="{{ url_for('ui.submission_status', submission_id=submission_id) }}" name="cancel" class="button is-danger" value="cancel" aria-label="Cancel" title="Cancel">Cancel</a>
-          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Submit</button>
+          {% if require_confirmation and not confirmed %}
+          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Update</button>
+          <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm">Confirm & Submit</button>
+          {% else %}
+          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Proceed</button>
+          {% endif %}
       </div>
     </form>
   </content>

--- a/submit/templates/submit/jref.html
+++ b/submit/templates/submit/jref.html
@@ -9,6 +9,15 @@
 
 {% block content %}
   <h1 class="title">Update journal reference</h1>
+  <p>
+    When an article is published, the author may wish to indicate this in the
+    abstract listing for the article. For this reason, the journal reference
+    and DOI (Digital Object Identifier) fields are provided for articles.
+    Additionally, a report number field is provided for institutional report
+    numbers.
+  </p>
+  <h2>arXiv:{{ submission.arxiv_id }}v{{ submission.version }} {{ submission.metadata.title }}</h2>
+  <p>{{ submission.metadata.authors_disay }}</p>
   <content>
 
 
@@ -90,7 +99,7 @@
       {% endwith %}
 
       <div class="buttons submit-nav" role="navigation">
-          <button name="cancel" class="button has-text-grey is-light is-outlined" style="border:0" value="cancel" aria-label="Cancel submission" title="Cancel submission"><span class="icon"><i class="fa fa-trash fa-lg"></i></button>
+          <a href="{{ url_for('ui.submission_status', submission_id=submission_id) }}" name="cancel" class="button is-danger" value="cancel" aria-label="Cancel" title="Cancel">Cancel</a>
           <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Submit</button>
       </div>
     </form>

--- a/submit/templates/submit/status.html
+++ b/submit/templates/submit/status.html
@@ -1,0 +1,24 @@
+{% extends "submit/base.html" %}
+
+{% block title -%}{{ submission.status }}{%- endblock title %}
+
+{% block within_content %}
+
+<p>
+  This is for dev/debugging. We need to implement this page with a real
+  layout that communicates what's going on with a user's submission.
+</p>
+<pre>
+{{ submission.to_dict()|pprint }}
+</pre>
+
+{% for event in events %}
+<li class="">
+  {{ event.NAMED.capitalize() }} {{ event.created|timesince }}
+  <pre>
+  {{ event.to_dict()|pprint }}
+  </pre>
+</li>
+{% endfor %}
+
+{% endblock within_content %}

--- a/submit/templates/submit/status.html
+++ b/submit/templates/submit/status.html
@@ -3,11 +3,15 @@
 {% block title -%}{{ submission.status }}{%- endblock title %}
 
 {% block within_content %}
-
 <p>
   This is for dev/debugging. We need to implement this page with a real
   layout that communicates what's going on with a user's submission.
 </p>
+
+<a href="{{ url_for('ui.publish', submission_id=submission_id) }}" class="button is-link">
+  Click me to set the submission to published which cannot be undone and is for testing purposes only
+</a>
+
 <pre>
 {{ submission.to_dict()|pprint }}
 </pre>

--- a/submit/tests/test_workflow.py
+++ b/submit/tests/test_workflow.py
@@ -12,6 +12,10 @@ from arxiv.submission.services import classic
 from arxiv.users.auth import scopes
 from arxiv.users.domain import Category
 from arxiv import status
+from arxiv.submission.domain.event import *
+from arxiv.submission.domain.agent import User
+from arxiv.submission.domain.submission import Author
+from arxiv.submission import save
 
 CSRF_PATTERN = (r'\<input id="csrf_token" name="csrf_token" type="hidden"'
                 r' value="([^\"]+)">')
@@ -181,3 +185,122 @@ class TestSubmissionWorkflow(TestCase):
         response = self.client.get(next_page.path, headers=self.headers)
         self.assertIn(b'Upload files', response.data)
         token = self._parse_csrf_token(response)
+
+
+class TestJREFWorkflow(TestCase):
+    """Tests that progress through the JREF workflow."""
+
+    def setUp(self):
+        """Create an application instance."""
+        self.app = create_ui_web_app()
+        os.environ['JWT_SECRET'] = self.app.config.get('JWT_SECRET')
+        _, self.db = tempfile.mkstemp(suffix='.db')
+        self.app.config['CLASSIC_DATABASE_URI'] = f'sqlite:///{self.db}'
+        self.user = User('1234', 'foo@bar.com', endorsements=['astro-ph.GA'])
+        self.token = generate_token('1234', 'foo@bar.com', 'foouser',
+                                    scope=[scopes.CREATE_SUBMISSION,
+                                           scopes.EDIT_SUBMISSION,
+                                           scopes.VIEW_SUBMISSION,
+                                           scopes.READ_UPLOAD,
+                                           scopes.WRITE_UPLOAD,
+                                           scopes.DELETE_UPLOAD_FILE],
+                                    endorsements=[
+                                        Category('astro-ph', 'GA'),
+                                        Category('astro-ph', 'CO'),
+                                    ])
+        self.headers = {'Authorization': self.token}
+        self.client = self.app.test_client()
+
+        # Create and publish a submission.
+        with self.app.app_context():
+            classic.create_all()
+            session = classic.current_session()
+
+            cc0 = 'http://creativecommons.org/publicdomain/zero/1.0/'
+            self.submission, _ = save(
+                CreateSubmission(creator=self.user),
+                ConfirmContactInformation(creator=self.user),
+                ConfirmAuthorship(creator=self.user, submitter_is_author=True),
+                SetLicense(
+                    creator=self.user,
+                    license_uri=cc0,
+                    license_name='CC0 1.0'
+                ),
+                ConfirmPolicy(creator=self.user),
+                SetPrimaryClassification(creator=self.user,
+                                         category='astro-ph.GA'),
+                SetUploadPackage(
+                    creator=self.user,
+                    checksum="a9s9k342900skks03330029k",
+                    format='tex',
+                    identifier=123,
+                    size=593992
+                ),
+                SetTitle(creator=self.user, title='foo title'),
+                SetAbstract(creator=self.user, abstract='ab stract' * 20),
+                SetComments(creator=self.user, comments='indeed'),
+                SetReportNumber(creator=self.user, report_num='the number 12'),
+                SetAuthors(
+                    creator=self.user,
+                    authors=[Author(
+                        order=0,
+                        forename='Bob',
+                        surname='Paulson',
+                        email='Robert.Paulson@nowhere.edu',
+                        affiliation='Fight Club'
+                    )]
+                ),
+                FinalizeSubmission(creator=self.user)
+            )
+
+            # Published!
+            db_submission = session.query(classic.models.Submission) \
+                .get(self.submission.submission_id)
+            db_submission.status = classic.models.Submission.PUBLISHED
+            db_document = classic.models.Document(paper_id='1234.5678')
+            db_submission.doc_paper_id = '1234.5678'
+            db_submission.document = db_document
+            session.add(db_submission)
+            session.add(db_document)
+            session.commit()
+
+        self.submission_id = self.submission.submission_id
+
+    def tearDown(self):
+        """Remove the temporary database."""
+        os.remove(self.db)
+
+    def _parse_csrf_token(self, response):
+        try:
+            match = re.search(CSRF_PATTERN, response.data.decode('utf-8'))
+            token = match.group(1)
+        except AttributeError:
+            self.fail('Could not find CSRF token')
+        return token
+
+    def test_create_submission(self):
+        """User creates a new submission, and proceeds up to upload stage."""
+        # Get the JREF page.
+        endpoint = f'/{self.submission_id}/jref'
+        response = self.client.get(endpoint, headers=self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content_type, 'text/html; charset=utf-8')
+        self.assertIn(b'Journal reference', response.data)
+        token = self._parse_csrf_token(response)
+
+        # Set the DOI, journal reference, report number.
+        request_data = {'doi': '10.1000/182',
+                        'journal_ref': 'foo journal 1992',
+                        'report_num': 'abc report 42',
+                        'csrf_token': token}
+        response = self.client.post(endpoint, data=request_data,
+                                    headers=self.headers)
+        self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
+
+        with self.app.app_context():
+            session = classic.current_session()
+            # What happened.
+            db_submission = session.query(classic.models.Submission) \
+                .filter(classic.models.Submission.doc_paper_id == '1234.5678')
+            self.assertEqual(db_submission.count(), 4,
+                             "Creates a second row for the JREF")

--- a/submit/tests/test_workflow.py
+++ b/submit/tests/test_workflow.py
@@ -295,6 +295,15 @@ class TestJREFWorkflow(TestCase):
                         'csrf_token': token}
         response = self.client.post(endpoint, data=request_data,
                                     headers=self.headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content_type, 'text/html; charset=utf-8')
+        self.assertIn(b'Confirm & Submit', response.data)
+        token = self._parse_csrf_token(response)
+
+        request_data['confirmed'] = True
+        request_data['csrf_token'] = token
+        response = self.client.post(endpoint, data=request_data,
+                                    headers=self.headers)
         self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
 
         with self.app.app_context():
@@ -302,5 +311,5 @@ class TestJREFWorkflow(TestCase):
             # What happened.
             db_submission = session.query(classic.models.Submission) \
                 .filter(classic.models.Submission.doc_paper_id == '1234.5678')
-            self.assertEqual(db_submission.count(), 4,
+            self.assertEqual(db_submission.count(), 2,
                              "Creates a second row for the JREF")

--- a/submit/util.py
+++ b/submit/util.py
@@ -1,7 +1,7 @@
 """Utilities and helpers for the :mod:`submit` application."""
 
 from typing import Optional, Tuple, List
-
+from datetime import datetime
 from werkzeug.exceptions import NotFound
 
 from arxiv.base.globals import get_application_global
@@ -44,15 +44,18 @@ def load_submission(submission_id: Optional[int]) \
     return submission, submission_events
 
 
-# TODO: remove me! 
+# TODO: remove me!
 def publish_submission(submission_id: int) -> None:
     """WARNING WARNING WARNING this is for testing purposes only."""
     session = events.services.classic.current_session()
     db_submission = session.query(events.services.classic.models.Submission) \
         .get(submission_id)
     db_submission.status = events.services.classic.models.Submission.PUBLISHED
-    db_document = events.services.classic.models.Document(paper_id='1234.5678')
-    db_submission.doc_paper_id = '1234.5678'
+    paper_id = datetime.now().strftime('%s')[-4:] \
+        + "." \
+        + datetime.now().strftime('%s')[-5:]
+    db_document = events.services.classic.models.Document(paper_id=paper_id)
+    db_submission.doc_paper_id = paper_id
     db_submission.document = db_document
     session.add(db_submission)
     session.add(db_document)

--- a/submit/util.py
+++ b/submit/util.py
@@ -1,6 +1,6 @@
 """Utilities and helpers for the :mod:`submit` application."""
 
-from typing import Optional
+from typing import Optional, Tuple, List
 
 from werkzeug.exceptions import NotFound
 
@@ -8,7 +8,8 @@ from arxiv.base.globals import get_application_global
 import arxiv.submission as events
 
 
-def load_submission(submission_id: Optional[int]) -> events.domain.Submission:
+def load_submission(submission_id: Optional[int]) \
+        -> Tuple[events.domain.Submission, List[events.domain.Event]]:
     """
     Load a submission by ID.
 
@@ -32,11 +33,12 @@ def load_submission(submission_id: Optional[int]) -> events.domain.Submission:
     g = get_application_global()
     if g is None or f'submission_{submission_id}' not in g:
         try:
-            submission, _ = events.load(submission_id)
+            submission, submission_events = events.load(submission_id)
         except events.exceptions.NoSuchSubmission as e:
             raise NotFound('No such submission.') from e
         if g is not None:
-            setattr(g, f'submission_{submission_id}', submission)
+            setattr(g, f'submission_{submission_id}',
+                    (submission, submission_events))
     if g is not None:
         return getattr(g, f'submission_{submission_id}')
-    return submission
+    return submission, submission_events

--- a/submit/util.py
+++ b/submit/util.py
@@ -42,3 +42,18 @@ def load_submission(submission_id: Optional[int]) \
     if g is not None:
         return getattr(g, f'submission_{submission_id}')
     return submission, submission_events
+
+
+# TODO: remove me! 
+def publish_submission(submission_id: int) -> None:
+    """WARNING WARNING WARNING this is for testing purposes only."""
+    session = events.services.classic.current_session()
+    db_submission = session.query(events.services.classic.models.Submission) \
+        .get(submission_id)
+    db_submission.status = events.services.classic.models.Submission.PUBLISHED
+    db_document = events.services.classic.models.Document(paper_id='1234.5678')
+    db_submission.doc_paper_id = '1234.5678'
+    db_submission.document = db_document
+    session.add(db_submission)
+    session.add(db_document)
+    session.commit()


### PR DESCRIPTION
This leverages some refactoring in submission-core. This needs massive styling help, copy, etc. Mostly a conversation-starter. What should this look like?

Here's roughly how JREFs work in classic: a submission is published, and then a user wants to add a DOI or something. So they submit a pared-down submission that just updates DOI, journal ref, and/or report num. This works its way through the system, and the abs file eventually gets updated. The version number doesn't get changed.

Here's roughly how JREFs work in submission core: a submission is published, and then a user wants to add a DOI or something. We create SetDOI, SetJournalReference, and/or SetReportNum command(s). Right now this integrates with classic to create those pared down submissions in the database. Later on, we'll deal with those data some other way, probably (headed toward secondary metadata store).

This PR adds a route for JREFs. It is supposed to look a bit like the classic interface, but better. But it's still ugly and needs a lot of work. Here's the classic interface:
![image](https://user-images.githubusercontent.com/3451594/48812959-b0feb480-ed02-11e8-9c57-eb4380e366ec.png)

Here's the really ugly first pass at the JREF interface here:
![image](https://user-images.githubusercontent.com/3451594/48813111-67fb3000-ed03-11e8-98e7-dc2c3456a81b.png)

But note that if the submission is not published, you can't do a JREF. So you get bounced back to a really really ugly placeholder page for submission status, with an informative message.

![image](https://user-images.githubusercontent.com/3451594/48812995-dab7db80-ed02-11e8-83d7-8e60009443a6.png)

I also added this really ugly button to fake publishing the submission. You can click the ugly button, and then you'll see the status change. Also note the fake ``arxiv_id`` in the submission data.

![image](https://user-images.githubusercontent.com/3451594/48813099-5c0f6e00-ed03-11e8-8039-19756028143d.png)

and then go back to the ``/{submission_id}/jref`` page, and submit it. 

Here's a nice informative message.
![image](https://user-images.githubusercontent.com/3451594/48813227-fbccfc00-ed03-11e8-8ff5-5fd2c755a57b.png)

If you scroll down, you can see the last event that got created.

![image](https://user-images.githubusercontent.com/3451594/48813238-08515480-ed04-11e8-8262-114c88e670cc.png)
