### PR TITLE
ARXIVNG-1396 update text and display for withdrawal template

### DIFF
--- a/submit/config.py
+++ b/submit/config.py
@@ -89,7 +89,9 @@ URLS = [
     ("help_submit_pdf", "/help/submit_pdf", BASE_SERVER),
     ("help_submit_ps", "/help/submit_ps", BASE_SERVER),
     ("help_submit_html", "/help/submit_html", BASE_SERVER),
-    ("help_metadata", "/help/prep", BASE_SERVER)
+    ("help_metadata", "/help/prep", BASE_SERVER),
+    ("help_jref", "/help/jref", BASE_SERVER),
+    ("help_withdraw", "/help/withdraw", BASE_SERVER)
 ]
 """
 URLs for external services, for use with :func:`flask.url_for`.

--- a/submit/controllers/withdraw.py
+++ b/submit/controllers/withdraw.py
@@ -50,10 +50,10 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
     # Will raise NotFound if there is no such submission.
     submission, submission_events = load_submission(submission_id)
 
-    # The submission must be published for this to be a real JREF submission.
+    # The submission must be published for this to be a withdrawal request.
     if not submission.published:
         alerts.flash_failure(Markup("Submission must first be published. See "
-                                    "<a href='https://arxiv.org/help/jref'>"
+                                    "<a href='https://arxiv.org/help/withdraw'>"
                                     "the arXiv help pages</a> for details."))
         status_url = url_for('ui.submission_status',
                              submission_id=submission_id)

--- a/submit/templates/submit/jref.html
+++ b/submit/templates/submit/jref.html
@@ -126,7 +126,7 @@
           <a href="{{ url_for('ui.submission_status', submission_id=submission_id) }}" name="cancel" class="button is-danger" value="cancel" aria-label="Cancel" title="Cancel">Cancel</a>
           {% if require_confirmation and not confirmed %}
           <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Update</button>
-          <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm">Confirm & Submit</button>
+          <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm">Confirm and Submit</button>
           {% else %}
           <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Proceed</button>
           {% endif %}

--- a/submit/templates/submit/withdraw.html
+++ b/submit/templates/submit/withdraw.html
@@ -8,29 +8,35 @@
 {% endblock addl_head %}
 
 {% block content %}
-  <h1 class="title">Update journal reference</h1>
-  <p>
-    Articles that have been announced and made public cannot be completely
-    removed. However, you may submit a withdrawal notification for your
-    article.
-  </p>
+  <h1 class="title">Withdraw article</h1>
+
   {% if require_confirmation and not confirmed %}
   <div class="notification is-info">
-    Please review the preview of your paper's abstract page, and confirm that
-    you with to proceed. You can continue to make changes until you are
-    satisfied with the result.
+    <p>This preview shows the abstract page as it will be updated. Please
+    check carefully to ensure that it is correct. You can continue to
+    make changes until you are satisfied with the result.</p>
   </div>
-  {% endif %}
+
+  <div class="box">
+    <p>The abs-page preview goes here, and shows these values in context.</p>
+    <dl>
+      <dt>Withdrawal reason</dt>
+      <dd>{{ form.withdrawal_reason.data }}</dd>
+    </dl>
+  </div>
+  {% else %}
   <h2>arXiv:{{ submission.arxiv_id }}v{{ submission.version }} {{ submission.metadata.title }}</h2>
+  {% endif %}
+
   <content>
     <form method="POST" action="{{ url_for('ui.withdraw', submission_id=submission_id) }}">
       <div class="columns">
         <div class="column">
           {{ form.csrf_token }}
           {% with field = form.withdrawal_reason %}
-          <div class="field is-short-field">
+          <div class="field">
             <div class="control">
-              <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+              <label class="label" for="withdrawal_reason">{{ field.label.text }} (required) <a class="help-bubble" href="{{ url_for('help_withdraw') }}"><i class="fa fa-question-circle is-info"></i><div class="bubble-text">Specific reason for withdrawal will be placed in the Comments display for your article.</div></a></label>
               {% if field.errors %}
                 <div class="help is-danger">
                   {% for error in field.errors %}
@@ -53,25 +59,36 @@
           {% endwith %}
 
         </div>
-        <div class="column">
+        <div class="column" style="align-self: flex-end">
+          <div class="message is-link">
           {% if require_confirmation and not confirmed %}
-          <div class="box">
-            <p>The abs-page preview goes here, and shows these values in context.</p>
-            <dl>
-              <dt>Withdrawal reason</dt>
-              <dd>{{ form.withdrawal_reason.data }}</dd>
-            </dl>
-          </div>
+            <div class="message-header">
+              <p><span class="icon"><i class="fa fa-info-circle"></i></span> Noticed a typo or odd character?</p>
+            </div>
+            <div class="message-body">
+              <p>
+                If the preview doesn't look right, correct it in the form field and use the "Edit" button to make changes.
+              </p>
+            </div>
+          {% else %}
+            <div class="message-body">
+              <p>
+                Articles that have been announced and made public cannot be
+                completely removed. However, you may submit a withdrawal
+                notification for your article. Previously published versions of this article will still be publicly available.
+              </p>
+            </div>
           {% endif %}
+          </div>
         </div>
       </div>
       <div class="buttons submit-nav" role="navigation">
-          <a href="{{ url_for('ui.submission_status', submission_id=submission_id) }}" name="cancel" class="button is-danger" value="cancel" aria-label="Cancel" title="Cancel">Cancel</a>
+          <a href="{{ url_for('ui.submission_status', submission_id=submission_id) }}" name="cancel" class="button is-outlined" value="cancel" aria-label="Cancel">Cancel</a>
           {% if require_confirmation and not confirmed %}
-          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Update</button>
-          <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm">Confirm & Submit</button>
+          <button name="action" type="submit" class="button is-link is-outlined" value="submit" aria-label="Edit">Edit</button>
+          <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm and Submit">Confirm and Submit</button>
           {% else %}
-          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Submit">Proceed</button>
+          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Preview">Preview Withdrawal Notice</button>
           {% endif %}
       </div>
     </form>

--- a/submit/tests/test_workflow.py
+++ b/submit/tests/test_workflow.py
@@ -297,7 +297,7 @@ class TestJREFWorkflow(TestCase):
                                     headers=self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content_type, 'text/html; charset=utf-8')
-        self.assertIn(b'Confirm & Submit', response.data)
+        self.assertIn(b'Confirm and Submit', response.data)
         token = self._parse_csrf_token(response)
 
         request_data['confirmed'] = True
@@ -431,7 +431,7 @@ class TestWithdrawalWorkflow(TestCase):
                                     headers=self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content_type, 'text/html; charset=utf-8')
-        self.assertIn(b'Confirm & Submit', response.data)
+        self.assertIn(b'Confirm and Submit', response.data)
         token = self._parse_csrf_token(response)
 
         # Confirm the withdrawal request.


### PR DESCRIPTION
Carried over layout and text suggestions from ARXIVNG-1341.
Accessibility scan using WAVE is clean.

<img width="1111" alt="screen shot 2018-11-29 at 3 50 53 pm" src="https://user-images.githubusercontent.com/17456668/49251517-91951500-f3ef-11e8-9380-ffa9eb6d19fc.png">

<img width="1017" alt="screen shot 2018-11-29 at 3 51 08 pm" src="https://user-images.githubusercontent.com/17456668/49251522-9659c900-f3ef-11e8-90d2-8047ec0ccba2.png">
