### PR TITLE
ARXIVNG-1408 cross-list support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ bleach = "*"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.11.1"
-arxiv-submission-core = "==0.5.3rc2"
+arxiv-submission-core = "==0.5.3rc3"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.11.1"
 arxiv-submission-core = "==0.5.2"
+"3a3786f" = {path = "./../arxiv-submission-core/core"}
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -16,8 +16,7 @@ bleach = "*"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.11.1"
-arxiv-submission-core = "==0.5.2"
-"3a3786f" = {path = "./../arxiv-submission-core/core"}
+arxiv-submission-core = "==0.5.3rc2"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c4bbb582ff8141ae60d423851c507cd58703f32939b5427536f96088b5e260de"
+            "sha256": "97f011ad5b95ec213be9cc9625c133ee020a3315ed0232c19de86762714c3650"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,9 +14,6 @@
         ]
     },
     "default": {
-        "3a3786f": {
-            "path": "./../arxiv-submission-core/core"
-        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:c391381cc94b83a9173c383b78b06d5a77d5d124d5686577ba8466e68012fd80"
@@ -33,10 +30,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:ab0a2626b51db10b211ffb4b086d1e1e8a574f9816f63733f6840027f8351dc5"
+                "sha256:610b155af772c4cc1a748914ea3ab694d8672df082719004ac5f48ad99a5c428"
             ],
             "index": "pypi",
-            "version": "==0.5.2"
+            "version": "==0.5.3rc2"
         },
         "bleach": {
             "hashes": [
@@ -48,17 +45,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:1bb0505de52201ed2f3bafe3b4b1539971a4b08ff048b9d804f6e04f017701fb",
-                "sha256:730c585f7f8031993bd6e3a4d8d0ba62a59efdff2fe38ee073349223f9d6a4b7"
+                "sha256:4f52d5345a2dcaae62f03d194416ec7461faf367b4d885e6319c62fcef5f6a42",
+                "sha256:6e9f48f3cd16f4b4e1e2d9c49c0644568294f67cda1a93f84315526cbd7e70ae"
             ],
-            "version": "==1.9.59"
+            "version": "==1.9.60"
         },
         "botocore": {
             "hashes": [
-                "sha256:1bbcc9273899e1b14ab4d00660ce5c6dc23d699a391e11f421e5dff2d3a7014b",
-                "sha256:bcc4ae773091ed632eaf4a6d5bc46c6409659ce138158ec11904a931b21bd8f8"
+                "sha256:ad523b7e530b8fd51b8207ad1c981852399ec8f21b2c32311139daa8b2cbb55e",
+                "sha256:e298eaa3883d5aa62a21e84b68a3b4d47b582fffdb93efefe53144d2ed9a824c"
             ],
-            "version": "==1.12.59"
+            "version": "==1.12.60"
         },
         "certifi": {
             "hashes": [
@@ -202,6 +199,7 @@
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
                 "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
+            "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
         },
         "pytz": {
@@ -542,7 +540,6 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
-            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
         },
         "urllib3": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a451cea8156e3dfb7c42f5f141a89a65bf09ffb66e9097187e1b4c8e1dc2faf"
+            "sha256": "c4bbb582ff8141ae60d423851c507cd58703f32939b5427536f96088b5e260de"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,9 @@
         ]
     },
     "default": {
+        "3a3786f": {
+            "path": "./../arxiv-submission-core/core"
+        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:c391381cc94b83a9173c383b78b06d5a77d5d124d5686577ba8466e68012fd80"
@@ -45,17 +48,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0a0c0f0859a2be56b23823f8c1d50abf3c89d7d4d054019f24de69eeee9ad75c",
-                "sha256:b429d48b8e99a9fdd18c3aef68370f779e0aa76cfe275a55e1adff427d44ca9a"
+                "sha256:1bb0505de52201ed2f3bafe3b4b1539971a4b08ff048b9d804f6e04f017701fb",
+                "sha256:730c585f7f8031993bd6e3a4d8d0ba62a59efdff2fe38ee073349223f9d6a4b7"
             ],
-            "version": "==1.9.57"
+            "version": "==1.9.59"
         },
         "botocore": {
             "hashes": [
-                "sha256:6b9edd1e18436bce8b28b95b3dec582588080a90b5636abc1b3a795f5a0e6cf3",
-                "sha256:9dac7753d81e8a725b9a169fd63b43d2a3caeceb51de3fafd5e5bd10e25589cb"
+                "sha256:1bbcc9273899e1b14ab4d00660ce5c6dc23d699a391e11f421e5dff2d3a7014b",
+                "sha256:bcc4ae773091ed632eaf4a6d5bc46c6409659ce138158ec11904a931b21bd8f8"
             ],
-            "version": "==1.12.57"
+            "version": "==1.12.59"
         },
         "certifi": {
             "hashes": [
@@ -173,9 +176,11 @@
         },
         "mysqlclient": {
             "hashes": [
-                "sha256:ff8ee1be84215e6c30a746b728c41eb0701a46ca76e343af445b35ce6250644f"
+                "sha256:062d78953acb23066c0387a8f3bd0ecf946626f599145bb7fd201460e8f773e1",
+                "sha256:3981ae9ce545901a36a8b7aed76ed02960a429f75dc53b7ad77fb2f9ab7cd56b",
+                "sha256:b3591a00c0366de71d65108627899710d9cfb00e575c4d211aa8de59b1f130c9"
             ],
-            "version": "==1.3.13"
+            "version": "==1.3.14"
         },
         "pycountry": {
             "hashes": [
@@ -271,6 +276,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "uwsgi": {
@@ -536,6 +542,7 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
         },
         "urllib3": {
@@ -543,6 +550,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "wrapt": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "97f011ad5b95ec213be9cc9625c133ee020a3315ed0232c19de86762714c3650"
+            "sha256": "2a5565f5e32de2f9522ff87fff2b156e03725784d2b61f03531784f21cd9460f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -30,10 +30,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:610b155af772c4cc1a748914ea3ab694d8672df082719004ac5f48ad99a5c428"
+                "sha256:8fb5a3272f704110c199eff61bff56df29377ddf225376df5f378d19c163fda1"
             ],
             "index": "pypi",
-            "version": "==0.5.3rc2"
+            "version": "==0.5.3rc3"
         },
         "bleach": {
             "hashes": [
@@ -199,7 +199,6 @@
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
                 "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
-            "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
         },
         "pytz": {

--- a/submit/controllers/__init__.py
+++ b/submit/controllers/__init__.py
@@ -11,7 +11,7 @@ from .upload import delete_all as delete_all_files
 
 from ..util import load_submission
 from . import create, verify_user, authorship, license, policy, \
-    classification, metadata, util, jref, withdraw, delete
+    classification, metadata, util, jref, withdraw, delete, cross
 from .util import Response
 
 __all__ = ('verify_user', 'authorship', 'license', 'policy', 'classification',

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -59,7 +59,7 @@ class ClassificationForm(csrf.CSRFForm):
         choices = [
             (archive, [
                 (category, display) for category, display in archive_choices
-                if (allowed is None or category in allowed
+                if ((allowed is None or category in allowed)
                     and (primary is None or category != primary.category)
                     and category not in submission.secondary_categories)
                 or category == selected

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -32,11 +32,10 @@ class ClassificationForm(csrf.CSRFForm):
     CATEGORIES = [
         (archive['name'], [
             (category_id, f"{category['name']} ({category_id})")
-            for category_id, category in taxonomy.CATEGORIES.items()
-            if category['is_active'] and category['in_archive'] == archive_id
+            for category_id, category in taxonomy.CATEGORIES_ACTIVE.items()
+            if category['in_archive'] == archive_id
         ])
-        for archive_id, archive in taxonomy.ARCHIVES.items()
-        if 'end_date' not in archive
+        for archive_id, archive in taxonomy.ARCHIVES_ACTIVE.items()
     ]
     """Categories grouped by archive."""
 
@@ -55,8 +54,6 @@ class ClassificationForm(csrf.CSRFForm):
             -> None:
         """Remove redundant choices, and limit to endorsed categories."""
         selected = self.category.data
-        secondaries = [kls.category for kls
-                       in submission.secondary_classification]
         primary = submission.primary_classification
 
         choices = [
@@ -64,7 +61,7 @@ class ClassificationForm(csrf.CSRFForm):
                 (category, display) for category, display in archive_choices
                 if (allowed is None or category in allowed
                     and (primary is None or category != primary.category)
-                    and category not in secondaries)
+                    and category not in submission.secondary_categories)
                 or category == selected
             ])
             for archive, archive_choices in self.category.choices

--- a/submit/controllers/cross.py
+++ b/submit/controllers/cross.py
@@ -1,0 +1,150 @@
+"""Controller for cross-list requests."""
+
+from typing import Tuple, Dict, Any, Optional, List
+
+from werkzeug import MultiDict
+from werkzeug.exceptions import InternalServerError, NotFound
+
+from flask import url_for, Markup
+from wtforms.fields import TextField, TextAreaField, Field, BooleanField
+from wtforms.validators import InputRequired, ValidationError, optional, \
+    DataRequired
+
+from arxiv import status, taxonomy
+from arxiv.base import logging, alerts
+from arxiv.forms import csrf
+from arxiv.users.domain import Session
+import arxiv.submission as events
+
+from ..util import load_submission
+from . import util
+
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
+
+Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
+
+
+class CrossListForm(csrf.CSRFForm, util.FieldMixin, util.SubmissionMixin):
+    """Submit a cross-list request."""
+
+    CATEGORIES = [
+        (archive['name'], [
+            (category_id, f"{category['name']} ({category_id})")
+            for category_id, category in taxonomy.CATEGORIES_ACTIVE.items()
+            if category['in_archive'] == archive_id
+        ])
+        for archive_id, archive in taxonomy.ARCHIVES_ACTIVE.items()
+    ]
+    """Categories grouped by archive."""
+
+    categories = util.OptGroupSelectMultipleField('Categories',
+                                                  choices=CATEGORIES,
+                                                  default='')
+    confirmed = BooleanField('Confirmed',
+                             false_values=('false', False, 0, '0', ''))
+
+    def validate_categories(form: csrf.CSRFForm, field: Field) -> None:
+        """Validate the reason provided for the withdrawal."""
+        if field.data:
+            form._validate_event(events.RequestCrossList,
+                                 categories=field.data)
+
+    def filter_choices(self, submission: events.domain.Submission,
+                       session: Session,
+                       allowed: Optional[List[str]] = None) -> None:
+        """Remove redundant choices, and limit to endorsed categories."""
+        selected: List[str] = self.category.data
+        primary = submission.primary_classification
+
+        choices = [
+            (archive, [
+                (category, display) for category, display in archive_choices
+                if (allowed is None or category in allowed
+                    and (primary is None or category != primary.category)
+                    and category not in submission.secondary_categories)
+                or category in selected
+            ])
+            for archive, archive_choices in self.category.choices
+        ]
+        self.categories.choices = [
+            (archive, _choices) for archive, _choices in choices
+            if len(_choices) > 0
+        ]
+
+
+def request_cross(method: str, params: MultiDict, session: Session,
+                  submission_id: int) -> Response:
+    """Request cross-list classification for an announced e-print."""
+    submitter, client = util.user_and_client_from_session(session)
+    logger.debug(f'method: {method}, submission: {submission_id}. {params}')
+
+    # Will raise NotFound if there is no such submission.
+    submission, submission_events = load_submission(submission_id)
+
+    # The submission must be published for this to be a withdrawal request.
+    if not submission.published:
+        alerts.flash_failure(
+            Markup("Submission must first be published. See <a"
+                   " href='https://arxiv.org/help/withdraw'>the arXiv help"
+                   " pages</a> for details."))
+        status_url = url_for('ui.create_submission')
+        return {}, status.HTTP_303_SEE_OTHER, {'Location': status_url}
+
+    # The form should be prepopulated based on the current state of the
+    # submission.
+    if method == 'GET':
+        params = MultiDict({})
+
+    params.setdefault("confirmed", False)
+    form = CrossListForm(params)
+    form.submission = submission
+    form.creator = submitter
+    response_data = {
+        'submission_id': submission_id,
+        'submission': submission,
+        'form': form,
+    }
+    print("data::", form.data)
+
+    if method == 'POST':
+        # We require the user to confirm that they wish to proceed.
+        if not form.validate():
+            logger.debug('Invalid form data; return bad request')
+            return response_data, status.HTTP_400_BAD_REQUEST, {}
+
+        elif not form.events:
+            pass
+        elif not form.confirmed.data:
+            response_data['require_confirmation'] = True
+            logger.debug('Not confirmed')
+            return response_data, status.HTTP_200_OK, {}
+
+        # form.events get set by the SubmissionMixin during validation.
+        # TODO: that's kind of indirect.
+        elif form.events:   # Metadata has changed.
+            response_data['require_confirmation'] = True
+            logger.debug('Form is valid, with data: %s', str(form.data))
+            try:
+                # Save the events created during form validation.
+                submission, stack = events.save(*form.events,
+                                                submission_id=submission_id)
+            except events.exceptions.InvalidStack as e:
+                logger.error('Could not request withdrawal: %s', str(e))
+                form.errors     # Causes the form to initialize errors.
+                form._errors['events'] = [
+                    ie.message for ie in e.event_exceptions
+                ]
+                logger.debug('InvalidStack; return bad request')
+                return response_data, status.HTTP_400_BAD_REQUEST, {}
+            except events.exceptions.SaveError as e:
+                logger.error('Could not save metadata event')
+                raise InternalServerError(
+                    'There was a problem saving this operation'
+                ) from e
+
+            # Success! Send user back to the submission page.
+            alerts.flash_success("Cross-list request submitted.")
+            status_url = url_for('ui.create_submission')
+            return {}, status.HTTP_303_SEE_OTHER, {'Location': status_url}
+    logger.debug('Nothing to do, return 200')
+    return response_data, status.HTTP_200_OK, {}

--- a/submit/controllers/cross.py
+++ b/submit/controllers/cross.py
@@ -130,7 +130,6 @@ def request_cross(method: str, params: MultiDict, session: Session,
 
     # Will raise NotFound if there is no such submission.
     submission, submission_events = load_submission(submission_id)
-    print("active user requests", submission.active_user_requests, submission.has_active_requests)
 
     # The submission must be published for this to be a withdrawal request.
     if not submission.published:

--- a/submit/controllers/cross.py
+++ b/submit/controllers/cross.py
@@ -128,11 +128,11 @@ def request_cross(method: str, params: MultiDict, session: Session,
     # Will raise NotFound if there is no such submission.
     submission, submission_events = load_submission(submission_id)
 
-    # The submission must be published for this to be a withdrawal request.
+    # The submission must be published for this to be a cross-list request.
     if not submission.published:
         alerts.flash_failure(
             Markup("Submission must first be published. See <a"
-                   " href='https://arxiv.org/help/withdraw'>the arXiv help"
+                   " href='https://arxiv.org/help/cross'>the arXiv help"
                    " pages</a> for details."))
         status_url = url_for('ui.create_submission')
         return {}, status.HTTP_303_SEE_OTHER, {'Location': status_url}

--- a/submit/controllers/util.py
+++ b/submit/controllers/util.py
@@ -12,7 +12,7 @@ from wtforms import StringField, PasswordField, SelectField, \
     SelectMultipleField, Form, validators
 from wtforms.fields.core import UnboundField
 
-from arxiv import status
+from arxiv import status, taxonomy
 from arxiv.users.domain import Session
 import arxiv.submission as events
 from ..domain import SubmissionStage
@@ -64,13 +64,13 @@ class OptGroupSelectMultipleField(SelectMultipleField):
 
     widget = OptGroupSelectWidget(multiple=True)
 
-    def pre_validate(self, form: Form) -> None:
-        """Don't forget to validate also values from embedded lists."""
-        for group_label, items in self.choices:
-            for value, label in items:
-                if value == self.data:
-                    return
-        raise ValueError(self.gettext('Not a valid choice'))
+    # def pre_validate(self, form: Form) -> None:
+    #     """Don't forget to validate also values from embedded lists."""
+    #     for group_label, items in self.choices:
+    #         for value, label in items:
+    #             if value == self.data:
+    #                 return
+    #     raise ValueError(self.gettext('Not a valid choice'))
 
     def _value(self) -> List[str]:
         data: List[str] = self.data

--- a/submit/controllers/util.py
+++ b/submit/controllers/util.py
@@ -59,6 +59,24 @@ class OptGroupSelectField(SelectField):
         return data
 
 
+class OptGroupSelectMultipleField(SelectMultipleField):
+    """A multiple select field with optgroups."""
+
+    widget = OptGroupSelectWidget(multiple=True)
+
+    def pre_validate(self, form: Form) -> None:
+        """Don't forget to validate also values from embedded lists."""
+        for group_label, items in self.choices:
+            for value, label in items:
+                if value == self.data:
+                    return
+        raise ValueError(self.gettext('Not a valid choice'))
+
+    def _value(self) -> List[str]:
+        data: List[str] = self.data
+        return data
+
+
 class SubmissionMixin:
     """
     Provides submission-related integration for :class:`.Form`s.

--- a/submit/factory.py
+++ b/submit/factory.py
@@ -24,8 +24,7 @@ def create_ui_web_app() -> Flask:
     app.register_blueprint(ui.blueprint)
 
     wrap(app, [auth.middleware.AuthMiddleware])
-    app.jinja_env.filters['group_files'] = filters.group_files
-    app.jinja_env.filters['timesince'] = filters.timesince
-    app.jinja_env.filters['just_updated'] = filters.just_updated
+    for filter_name, filter_func in filters.get_filters():
+        app.jinja_env.filters[filter_name] = filter_func
     app.context_processor(ui.inject_get_next_stage_for_submission)
     return app

--- a/submit/filters.py
+++ b/submit/filters.py
@@ -1,9 +1,11 @@
 """Custom Jinja2 filters."""
 
+from typing import List, Tuple, Optional, Union, Dict, Mapping, Callable
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from pytz import UTC
-from typing import List, Tuple, Optional, Union, Dict, Mapping
+
+from arxiv import taxonomy
 from .domain import FileStatus, UploadStatus
 
 NestedFileTree = Mapping[str, Union[FileStatus, 'NestedFileTree']]
@@ -102,3 +104,36 @@ def just_updated(status: FileStatus, seconds: int = 2) -> bool:
     """
     now = datetime.now(tz=UTC)
     return abs((now - status.modified).seconds) < seconds
+
+
+def get_category_name(category: str) -> str:
+    """
+    Get the display name for a category in the :mod:`base:taxonomy`.
+
+    Parameters
+    ----------
+    category : str
+        Canonical category ID, e.g. ``astro-ph.HE``.
+
+    Returns
+    -------
+    str
+        Display name for the category.
+
+    Raises
+    ------
+    KeyError
+        Raised if the specified category is not found in the active categories.
+
+    """
+    return taxonomy.CATEGORIES_ACTIVE[category]['name']
+
+
+def get_filters() -> List[Tuple[str, Callable]]:
+    """Get the filter functions available in this module."""
+    return [
+        ('group_files', group_files),
+        ('timesince', timesince),
+        ('just_updated', just_updated),
+        ('get_category_name', get_category_name)
+    ]

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -515,6 +515,26 @@ def withdraw(submission_id: Optional[int] = None) -> Response:
     return Response(response=data, status=code, headers=headers)
 
 
+@blueprint.route('/<int:submission_id>/request_cross', methods=['GET', 'POST'])
+@auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION,
+                        authorizer=can_edit_submission)
+def request_cross(submission_id: Optional[int] = None) -> Response:
+    """Render the cross-list request page."""
+    request_data = MultiDict(request.form.items(multi=True))
+    data, code, headers = controllers.cross.request_cross(
+        request.method,
+        request_data,
+        request.session,
+        submission_id
+    )
+    if code in [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST]:
+        rendered = render_template("submit/request_cross_list.html",
+                                   pagetitle='Request cross-list',
+                                   **data)
+        return make_response(rendered, code)
+    return Response(response=data, status=code, headers=headers)
+
+
 def inject_get_next_stage_for_submission() -> Dict[str, Callable]:
     def get_next_stage_for_submission(this_submission: Submission) -> str:
         if this_submission.version == 1:

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -130,6 +130,53 @@ def place_on_hold(submission_id: int) -> Response:
                     headers={'Location': target})
 
 
+# TODO: remove me!!
+@blueprint.route('/<int:submission_id>/apply_cross', methods=['GET'])
+@auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION,
+                        authorizer=can_edit_submission)
+def apply_cross(submission_id: int) -> Response:
+    """WARNING WARNING WARNING this is for testing purposes only."""
+    util.apply_cross(submission_id)
+    target = url_for('ui.submission_status', submission_id=submission_id)
+    return Response(response={}, status=status.HTTP_303_SEE_OTHER,
+                    headers={'Location': target})
+
+
+# TODO: remove me!!
+@blueprint.route('/<int:submission_id>/reject_cross', methods=['GET'])
+@auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION,
+                        authorizer=can_edit_submission)
+def reject_cross(submission_id: int) -> Response:
+    """WARNING WARNING WARNING this is for testing purposes only."""
+    util.reject_cross(submission_id)
+    target = url_for('ui.submission_status', submission_id=submission_id)
+    return Response(response={}, status=status.HTTP_303_SEE_OTHER,
+                    headers={'Location': target})
+
+
+# TODO: remove me!!
+@blueprint.route('/<int:submission_id>/apply_withdrawal', methods=['GET'])
+@auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION,
+                        authorizer=can_edit_submission)
+def apply_withdrawal(submission_id: int) -> Response:
+    """WARNING WARNING WARNING this is for testing purposes only."""
+    util.apply_withdrawal(submission_id)
+    target = url_for('ui.submission_status', submission_id=submission_id)
+    return Response(response={}, status=status.HTTP_303_SEE_OTHER,
+                    headers={'Location': target})
+
+# TODO: remove me!!
+@blueprint.route('/<int:submission_id>/reject_withdrawal', methods=['GET'])
+@auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION,
+                        authorizer=can_edit_submission)
+def reject_withdrawal(submission_id: int) -> Response:
+    """WARNING WARNING WARNING this is for testing purposes only."""
+    util.reject_withdrawal(submission_id)
+    target = url_for('ui.submission_status', submission_id=submission_id)
+    return Response(response={}, status=status.HTTP_303_SEE_OTHER,
+                    headers={'Location': target})
+
+
 @blueprint.route('/<int:submission_id>/verify_user',
                  endpoint=Stages.VERIFY_USER.value,
                  methods=['GET', 'POST'])

--- a/submit/templates/submit/create.html
+++ b/submit/templates/submit/create.html
@@ -21,17 +21,27 @@
         {{ submission.status}}
         {% if submission.published %}
         <div class="level-right">
+          {% if submission.has_active_requests %}
+            {% for request in submission.active_user_requests %}
+            <div class="tags has-addons">
+              <span class="tag is-dark">{{ request.NAME }}</span>
+              <span class="tag is-info">{{ request.status }}</span>
+            </div>
+            {% endfor %}
+          {% else %}
           <form class="form" method="POST" action="{{ url_for('ui.create_replacement', submission_id=submission.submission_id) }}">
             {{ form.csrf_token }}
             <button name="new" class="button is-link is-small" value="new" aria-label="New version (replacement)">New version</button>
             <a href="{{ url_for('ui.jref', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Update journal reference">Update journal reference</a>
             <a href="{{ url_for('ui.withdraw', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Request withdrawal">Request withdrawal</a>
+            <a href="{{ url_for('ui.request_cross', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Request cross-list">Request cross-list</a>
           </form>
+          {% endif %}
 
         </div>
         {% endif %}
       </div>
-      {% if not submission.published %}
+      {% if not submission.published and not submission.has_active_requests %}
       <li>
         <a href="{{ get_next_stage_for_submission(submission) }}">Version {{ submission.version }}; updated {{ submission.updated|timesince }}</a>. <span class="tag">{{ submission.status }}</span>
         <a href="{{ url_for('ui.delete_submission', submission_id=submission.submission_id) }}">
@@ -42,7 +52,6 @@
       </li>
       {% endif %}
       {% for version in submission.versions %}
-
         <li>
           arXiv:{{ version.arxiv_id }}v{{ version.version }}; published {{ version.updated|timesince }}. <span class="tag">{{ version.status }}</span>
         </li>

--- a/submit/templates/submit/create.html
+++ b/submit/templates/submit/create.html
@@ -32,9 +32,9 @@
           <form class="form" method="POST" action="{{ url_for('ui.create_replacement', submission_id=submission.submission_id) }}">
             {{ form.csrf_token }}
             <button name="new" class="button is-link is-small" value="new" aria-label="New version (replacement)">New version</button>
-            <a href="{{ url_for('ui.jref', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Update journal reference">Update journal reference</a>
-            <a href="{{ url_for('ui.withdraw', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Request withdrawal">Request withdrawal</a>
-            <a href="{{ url_for('ui.request_cross', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Request cross-list">Request cross-list</a>
+            <a href="{{ url_for('ui.jref', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Update journal reference">JREF</a>
+            <a href="{{ url_for('ui.withdraw', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Request withdrawal">Withdraw</a>
+            <a href="{{ url_for('ui.request_cross', submission_id=submission.submission_id) }}" class="button is-link is-small" aria-label="Request cross-list">Cross-list</a>
           </form>
           {% endif %}
 
@@ -54,7 +54,15 @@
       {% for version in submission.versions %}
         <li>
           arXiv:{{ version.arxiv_id }}v{{ version.version }}; published {{ version.updated|timesince }}. <span class="tag">{{ version.status }}</span>
+          {% if version.user_requests %}
+            <ul style="margin-top: 0px;">
+              {% for request_id, request in version.user_requests.items() %}
+                <li>{{ request.NAME }} requested {{ request.created|timesince }}, {{ request.status }} {{ request.updated|timesince }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
         </li>
+
       {% endfor %}
     </div>
     {% endfor %}

--- a/submit/templates/submit/cross_list.html
+++ b/submit/templates/submit/cross_list.html
@@ -13,14 +13,14 @@
       </a>
     </p>
 
-    {% for category, (display, subform) in formset.items() %}
+    {% for category, subform in formset.items() %}
 
     <form method="POST" class="form form-margin" action="{{ url_for('ui.cross_list', submission_id=submission_id) }}">
       {{ form.csrf_token }}
       <p>
         {{ subform.operation }}
         {{ subform.category()|safe }}
-          <span class="tag" style="border: 1px solid #999;">{{ subform.category.data }}</span> <span>{{ display }}</span>
+          <span class="tag" style="border: 1px solid #999;">{{ subform.category.data }}</span> <span>{{ category|get_category_name }}</span>
         <button class="button is-outlined is-link is-small" style="border: 0" title="Remove category">
           <span class="icon"><i class="fa fa-trash"></i>
         </button>

--- a/submit/templates/submit/request_cross_list.html
+++ b/submit/templates/submit/request_cross_list.html
@@ -9,39 +9,72 @@
 
 {% block content %}
   <h1 class="title">Request cross-list classification</h1>
+  <p>
+    You may feel that your article is of direct interest to the readers of
+    a category other than the one to which you submitted your article. In
+    such cases you may cross-list your article to the other category so
+    that your article appears in the regular listing for that category
+    (in the cross-list section).
+  </p>
+  <p>
+    Note that readers consider excessive or inappropriate cross-listing to
+    be bad etiquette, so consider your cross-lists beforehand, and do not
+    cross-list excessively or without good reason. It is rarely appropriate
+    to add more than one or two cross-lists. Also note that you are
+    unlikely to know that a cross-list is appropriate unless you are
+    yourself a reader of the archive to which you are considering a
+    cross-list. Bad cross-lists will be removed.
+  </p>
+
+  <h2>arXiv:{{ submission.arxiv_id }}v{{ submission.version }} {{ submission.metadata.title }}</h2>
 
   {% if require_confirmation and not confirmed %}
-  <div class="notification is-info">
-    <p>notify</p>
-  </div>
 
-  <div class="box">
-    <p>The abs-page preview goes here, and shows these values in context.</p>
-    <dl>
-
-    </dl>
-  </div>
   {% else %}
-  <h2>arXiv:{{ submission.arxiv_id }}v{{ submission.version }} {{ submission.metadata.title }}</h2>
+
   {% endif %}
 
   <content>
-    <form method="POST" action="{{ url_for('ui.request_cross', submission_id=submission_id) }}">
       <div class="columns">
         <div class="column">
+
+          {# This formset is used to send POST requests to REMOVE secondaries from the list. #}
+          {% if formset %}
+            {% for category, subform in formset.items() %}
+            <form method="POST" class="form form-margin" action="{{ url_for('ui.request_cross', submission_id=submission_id) }}">
+              {{ form.csrf_token }}
+              <p>
+                {{ subform.operation }}
+                {% for cat in selected %}
+                  <input name="selected" value="{{ cat }}" type="hidden" />
+                {% endfor %}
+                {{ subform.category()|safe }}
+                  <span class="tag" style="border: 1px solid #999;">{{ subform.category.data }}</span> <span>{{ category|get_category_name }}</span>
+                  <button class="button is-outlined is-link is-small" style="border: 0" title="Remove category">
+                  <span class="icon"><i class="fa fa-trash"></i>
+                </button>
+              </p>
+            </form>
+            {% endfor %}
+          {% endif %}
+
+          {# This form is used to send POST requests to ADD secondaries to the list. #}
+          <form method="POST" action="{{ url_for('ui.request_cross', submission_id=submission_id) }}">
           {{ form.csrf_token }}
-          {% with field = form.categories %}
-          <div class="field">
+          {{ form.operation }}
+          {% for cat in selected %}
+            <input name="selected" value="{{ cat }}" type="hidden" />
+          {% endfor %}
+          {% with field = form.category %}
+          <div class="field has-addons" style="margin-bottom: 3em">
             <div class="control">
-              <label class="label" for="categories">
-                {{ field.label.text }} (required)
-                <a class="help-bubble" href="{{ url_for('help_cross') }}">
-                  <i class="fa fa-question-circle is-info"></i>
-                  <div class="bubble-text">
-                    Help text for cross list
-                  </div>
-                </a>
-              </label>
+              <div class="select">
+              {% if field.errors %}
+                {{ field(class="is-danger")|safe }}
+              {% else %}
+                {{ field()|safe }}
+              {% endif %}
+              </div>
               {% if field.errors %}
                 <div class="help is-danger">
                   {% for error in field.errors %}
@@ -50,29 +83,44 @@
                 </div>
               {% endif %}
               {% if field.description %}
-              <p class="help has-text-grey is-marginless">
+              <p class="help has-text-grey">
                 {{ field.description|safe }}
               </p>
               {% endif %}
-              {% if field.errors %}
-                {{ field(class="textarea is-danger")|safe }}
-              {% else %}
-                {{ field(class="textarea")|safe }}
-              {% endif %}
+            </div>
+            <div class="control">
+              <button class="button is-link">Add</button>
             </div>
           </div>
           {% endwith %}
-
+          </form>
         </div>
-        <div class="column" style="align-self: flex-end">
+        <div class="column">
+          <div class="message is-link">
+            <div class="message-header"><p class="is-size-6 is-white has-text-weight-semibold">Announced Categories</p></div>
+            <div class="message-body">
+              {% if primary %}
+              <p class="has-text-weight-bold" style="margin-bottom: .5em">
+                <span class="tag is-link">{{ submission.primary_classification.category }}</span> {{ submission.primary_classification.category|get_category_name }}
+              </p>
+              {% endif %}
+
+              {% for category in submission.secondary_categories %}
+              <p>
+                  <span class="tag" style="border: 1px solid #999;">{{ category }}</span> <span>{{ category|get_category_name }}</span>
+              </p>
+
+              {% endfor %}
+
+            </div>
+          </div>
+
           <div class="message is-link">
           {% if require_confirmation and not confirmed %}
-            <div class="message-header">
-              <p><span class="icon"><i class="fa fa-info-circle"></i></span> Noticed a typo or odd character?</p>
-            </div>
+
             <div class="message-body">
               <p>
-                If the preview doesn't look right, correct it in the form field and use the "Edit" button to make changes.
+                Message?
               </p>
             </div>
           {% else %}
@@ -88,12 +136,18 @@
       <div class="buttons submit-nav" role="navigation">
           <a href="{{ url_for('ui.submission_status', submission_id=submission_id) }}" name="cancel" class="button is-outlined" value="cancel" aria-label="Cancel">Cancel</a>
           {% if require_confirmation and not confirmed %}
-          <button name="action" type="submit" class="button is-link is-outlined" value="submit" aria-label="Edit">Edit</button>
-          <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm and Submit">Confirm and Submit</button>
+            <form method="POST" class="form form-margin" action="{{ url_for('ui.request_cross', submission_id=submission_id) }}">
+              {{ form.csrf_token }}
+              {% for cat in selected %}
+                <input name="selected" value="{{ cat }}" type="hidden" />
+              {% endfor %}
+              <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm and Submit">Confirm and Submit</button>
+            </form>
           {% else %}
-          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Preview">Preview Cross-List Classifications</button>
+            <span>Add cross-list categories using the menu above.</span>
           {% endif %}
+
       </div>
-    </form>
+
   </content>
 {% endblock content %}

--- a/submit/templates/submit/request_cross_list.html
+++ b/submit/templates/submit/request_cross_list.html
@@ -8,20 +8,17 @@
 {% endblock addl_head %}
 
 {% block content %}
-  <h1 class="title">Withdraw article</h1>
+  <h1 class="title">Request cross-list classification</h1>
 
   {% if require_confirmation and not confirmed %}
   <div class="notification is-info">
-    <p>This preview shows the abstract page as it will be updated. Please
-    check carefully to ensure that it is correct. You can continue to
-    make changes until you are satisfied with the result.</p>
+    <p>notify</p>
   </div>
 
   <div class="box">
     <p>The abs-page preview goes here, and shows these values in context.</p>
     <dl>
-      <dt>Withdrawal reason</dt>
-      <dd>{{ form.withdrawal_reason.data }}</dd>
+
     </dl>
   </div>
   {% else %}
@@ -29,14 +26,22 @@
   {% endif %}
 
   <content>
-    <form method="POST" action="{{ url_for('ui.withdraw', submission_id=submission_id) }}">
+    <form method="POST" action="{{ url_for('ui.request_cross', submission_id=submission_id) }}">
       <div class="columns">
         <div class="column">
           {{ form.csrf_token }}
-          {% with field = form.withdrawal_reason %}
+          {% with field = form.categories %}
           <div class="field">
             <div class="control">
-              <label class="label" for="withdrawal_reason">{{ field.label.text }} (required) <a class="help-bubble" href="{{ url_for('help_withdraw') }}"><i class="fa fa-question-circle is-info"></i><div class="bubble-text">Specific reason for withdrawal will be placed in the Comments display for your article.</div></a></label>
+              <label class="label" for="categories">
+                {{ field.label.text }} (required)
+                <a class="help-bubble" href="{{ url_for('help_cross') }}">
+                  <i class="fa fa-question-circle is-info"></i>
+                  <div class="bubble-text">
+                    Help text for cross list
+                  </div>
+                </a>
+              </label>
               {% if field.errors %}
                 <div class="help is-danger">
                   {% for error in field.errors %}
@@ -73,9 +78,7 @@
           {% else %}
             <div class="message-body">
               <p>
-                Articles that have been announced and made public cannot be
-                completely removed. However, you may submit a withdrawal
-                notification for your article. Previously published versions of this article will still be publicly available.
+                Message here
               </p>
             </div>
           {% endif %}
@@ -88,7 +91,7 @@
           <button name="action" type="submit" class="button is-link is-outlined" value="submit" aria-label="Edit">Edit</button>
           <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm and Submit">Confirm and Submit</button>
           {% else %}
-          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Preview">Preview Withdrawal Notice</button>
+          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Preview">Preview Cross-List Classifications</button>
           {% endif %}
       </div>
     </form>

--- a/submit/templates/submit/withdraw.html
+++ b/submit/templates/submit/withdraw.html
@@ -1,0 +1,96 @@
+{%- extends "base/base.html" %}
+
+{% import "submit/submit_macros.html" as submit_macros %}
+
+{% block addl_head %}
+ <link rel="stylesheet" href="{{ url_for('static', filename='css/submit.css')}}" />
+ <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
+{% endblock addl_head %}
+
+{% block content %}
+  <h1 class="title">Withdraw article</h1>
+
+  {% if require_confirmation and not confirmed %}
+  <div class="notification is-info">
+    <p>This preview shows the abstract page as it will be updated. Please
+    check carefully to ensure that it is correct. You can continue to
+    make changes until you are satisfied with the result.</p>
+  </div>
+
+  <div class="box">
+    <p>The abs-page preview goes here, and shows these values in context.</p>
+    <dl>
+      <dt>Withdrawal reason</dt>
+      <dd>{{ form.withdrawal_reason.data }}</dd>
+    </dl>
+  </div>
+  {% else %}
+  <h2>arXiv:{{ submission.arxiv_id }}v{{ submission.version }} {{ submission.metadata.title }}</h2>
+  {% endif %}
+
+  <content>
+    <form method="POST" action="{{ url_for('ui.withdraw', submission_id=submission_id) }}">
+      <div class="columns">
+        <div class="column">
+          {{ form.csrf_token }}
+          {% with field = form.withdrawal_reason %}
+          <div class="field">
+            <div class="control">
+              <label class="label" for="withdrawal_reason">{{ field.label.text }} (required) <a class="help-bubble" href="{{ url_for('help_withdraw') }}"><i class="fa fa-question-circle is-info"></i><div class="bubble-text">Specific reason for withdrawal will be placed in the Comments display for your article.</div></a></label>
+              {% if field.errors %}
+                <div class="help is-danger">
+                  {% for error in field.errors %}
+                      {{ error }}
+                  {% endfor %}
+                </div>
+              {% endif %}
+              {% if field.description %}
+              <p class="help has-text-grey is-marginless">
+                {{ field.description|safe }}
+              </p>
+              {% endif %}
+              {% if field.errors %}
+                {{ field(class="textarea is-danger")|safe }}
+              {% else %}
+                {{ field(class="textarea")|safe }}
+              {% endif %}
+            </div>
+          </div>
+          {% endwith %}
+
+        </div>
+        <div class="column" style="align-self: flex-end">
+          <div class="message is-link">
+          {% if require_confirmation and not confirmed %}
+            <div class="message-header">
+              <p><span class="icon"><i class="fa fa-info-circle"></i></span> Noticed a typo or odd character?</p>
+            </div>
+            <div class="message-body">
+              <p>
+                If the preview doesn't look right, correct it in the form field and use the "Edit" button to make changes.
+              </p>
+            </div>
+          {% else %}
+            <div class="message-body">
+              <p>
+                Articles that have been announced and made public cannot be
+                completely removed. However, you may submit a withdrawal
+                notification for your article. Previously published versions of this article will still be publicly available.
+              </p>
+            </div>
+          {% endif %}
+          </div>
+        </div>
+      </div>
+      <div class="buttons submit-nav" role="navigation">
+          <a href="{{ url_for('ui.submission_status', submission_id=submission_id) }}" name="cancel" class="button is-outlined" value="cancel" aria-label="Cancel">Cancel</a>
+          {% if require_confirmation and not confirmed %}
+          <button name="action" type="submit" class="button is-link is-outlined" value="submit" aria-label="Edit">Edit</button>
+          <button name="confirmed" type="submit" class="button is-success" value="1" aria-label="Confirm and Submit">Confirm and Submit</button>
+          {% else %}
+          <button name="action" type="submit" class="button is-link" value="submit" aria-label="Preview">Preview Withdrawal Notice</button>
+          {% endif %}
+      </div>
+    </form>
+  </content>
+{% endblock content %}

--- a/submit/util.py
+++ b/submit/util.py
@@ -77,3 +77,51 @@ def place_on_hold(submission_id: int) -> None:
     head.status = events.services.classic.models.Submission.ON_HOLD
     session.add(head)
     session.commit()
+
+
+# TODO: remove me!
+def apply_cross(submission_id: int) -> None:
+    session = events.services.classic.current_session()
+    dbss = events.services.classic._get_db_submission_rows(submission_id)
+    i = events.services.classic._get_head_idx(dbss)
+    for dbs in dbss[:i]:
+        if dbs.is_crosslist():
+            dbs.status = events.services.classic.models.Submission.PUBLISHED
+            session.add(dbs)
+            session.commit()
+
+
+# TODO: remove me!
+def reject_cross(submission_id: int) -> None:
+    session = events.services.classic.current_session()
+    dbss = events.services.classic._get_db_submission_rows(submission_id)
+    i = events.services.classic._get_head_idx(dbss)
+    for dbs in dbss[:i]:
+        if dbs.is_crosslist():
+            dbs.status = events.services.classic.models.Submission.REMOVED
+            session.add(dbs)
+            session.commit()
+
+
+# TODO: remove me!
+def apply_withdrawal(submission_id: int) -> None:
+    session = events.services.classic.current_session()
+    dbss = events.services.classic._get_db_submission_rows(submission_id)
+    i = events.services.classic._get_head_idx(dbss)
+    for dbs in dbss[:i]:
+        if dbs.is_withdrawal():
+            dbs.status = events.services.classic.models.Submission.PUBLISHED
+            session.add(dbs)
+            session.commit()
+
+
+# TODO: remove me!
+def reject_withdrawal(submission_id: int) -> None:
+    session = events.services.classic.current_session()
+    dbss = events.services.classic._get_db_submission_rows(submission_id)
+    i = events.services.classic._get_head_idx(dbss)
+    for dbs in dbss[:i]:
+        if dbs.is_withdrawal():
+            dbs.status = events.services.classic.models.Submission.REMOVED
+            session.add(dbs)
+            session.commit()


### PR DESCRIPTION
This introduces support for cross-list requests. This is a little different from adding cross-list categories during a new or replacement submission. What we're doing here is creating a new request (on the submission as ``Submission.user_requests: List[UserRequest]``) with a set of additional cross-list categories that the user would like added to an existing version.

Here's an example with a new submission that I started (got through classification steps), and then used the ``/{submission_id}/publish`` shortcut to artificially "publish" it.

![image](https://user-images.githubusercontent.com/3451594/49595545-32328a00-f946-11e8-95c5-25b3f9b3abe7.png)

The template needs a little work (looking for your direction @eawoods), but here's what the cross-list view looks like at the beginning. 

![image](https://user-images.githubusercontent.com/3451594/49595586-4bd3d180-f946-11e8-947a-fe8dd36ae8cd.png)

You can select a category that is not already on the submission, and add it to the request.

![image](https://user-images.githubusercontent.com/3451594/49596881-5348aa00-f949-11e8-9494-616d6ce10181.png)

You can add a bunch.

![image](https://user-images.githubusercontent.com/3451594/49597145-d10cb580-f949-11e8-92d1-6191b1a2b229.png)

And then submit the request.

![image](https://user-images.githubusercontent.com/3451594/49597173-e386ef00-f949-11e8-8a62-9cd4e2269909.png)

I added a route (dev/test only) for artificially "applying" the request. This is equivalent to the cross-list submission getting announced in the classic system. You can apply a cross-list request by making a GET request to ``/{submission id}/apply_cross``. This is just for testing so there isn't any visual feedback, but notice that the status of the request has changed.

![image](https://user-images.githubusercontent.com/3451594/49597247-074a3500-f94a-11e8-9cff-c0a0af9d0f99.png)

You can also simulate rejection by visiting ``/{submission id}/reject_cross``. Again, dev/test only. This will even work if you've already "applied" the request. Note the change in request status.

![image](https://user-images.githubusercontent.com/3451594/49597380-4bd5d080-f94a-11e8-83a2-1f3fb8fe2a20.png)

There may be some bugs lurking here or there. Don't forget to re-install dependencies, and consider starting with a fresh sqlite db.
