### PR TITLE
ARXIVNG-1371 Notify submitter that TeX source will be made public

### DIFF
--- a/submit/templates/submit/file_upload.html
+++ b/submit/templates/submit/file_upload.html
@@ -97,10 +97,9 @@
         <div class="message-body">
           <ul>
             <li>TeX and (La)TeX submissions are highly encouraged. This format is the most likely to retain readability and high-quality output in the future.</li>
-            <li>PDF documents created from TeX will not be accepted. The TeX source must be submitted and compiled by arXiv.
+            <li>PDF documents created from TeX are not typically accepted. The TeX source must be submitted and compiled by arXiv.
             <a href="{{ url_for('help_whytex') }}">Why?</a></li>
-            <li>TeX source uploaded to arXiv will be made publicly available.
-            <a href="{{ url_for('help_whytex') }}">Why?</a></li>
+            <li>TeX source uploaded to arXiv will be made publicly available.</li>
           </ul>
         </div>
       </div>
@@ -112,8 +111,7 @@
           <ul>
             <li><a href="{{ url_for('help_submit_tex') }}">(La)TeX, AMS(La)TeX, PDFLaTeX</a></li>
             <li><a href="{{ url_for('help_submit_pdf') }}">PDF</a></li>
-            <li><a href="{{ url_for('help_submit_ps') }}">PostScript</a></li>
-            <li><a href="{{ url_for('help_submit_html') }}">HTML</a></li>
+            <li><a href="{{ url_for('help_submit_html') }}">HTML (for proceedings index only)</a></li>
           </ul>
 
           <p class="has-text-weight-semibold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Accepted formats for figures</p>

--- a/submit/templates/submit/file_upload.html
+++ b/submit/templates/submit/file_upload.html
@@ -89,14 +89,21 @@
       <p class="title is-4 breathe-vertical has-text-centered">
         There's nothing here!
       </p>
+      {% endif %}
       <div class="message is-link">
+        <div class="message-header">
+          <p><span class="icon"><i class="fa fa-exclamation-triangle"></i></span>Submitting TeX</p>
+        </div>
         <div class="message-body">
-          <p><span class="icon has-text-link"><i class="fa fa-exclamation-triangle"></i></span>If this submission was written in TeX, TeX source must be submitted to be compiled by arXiv.
-          PDF documents created from TeX will not be accepted.
-          <a href="{{ url_for('help_whytex') }}">Why?</a></p>
+          <ul>
+            <li>TeX and (La)TeX submissions are highly encouraged. This format is the most likely to retain readability and high-quality output in the future.</li>
+            <li>PDF documents created from TeX will not be accepted. The TeX source must be submitted and compiled by arXiv.
+            <a href="{{ url_for('help_whytex') }}">Why?</a></li>
+            <li>TeX source uploaded to arXiv will be made publicly available.
+            <a href="{{ url_for('help_whytex') }}">Why?</a></li>
+          </ul>
         </div>
       </div>
-      {% endif %}
     </div>
     <div class="column is-one-third-desktop is-one-quarter-tablet">
       <div class="message is-info">


### PR DESCRIPTION
I combined all the TeX-related notices into one box.

<img width="842" alt="screen shot 2018-12-11 at 3 08 05 pm" src="https://user-images.githubusercontent.com/17456668/49827310-0143c200-fd57-11e8-965d-67092121d642.png">

Jim - including you as a reminder to myself to ping you on this and future notices that are largely UI-communication related (almost all my contributions in the next couple of weeks will be). I think you've seen this particular screen in exactly the same state on Friday - one last look before it gets incorporated? I was thinking it might be good to have a quick review on help text as we go in these last few weeks to alpha. If you'd rather look at things all at once rather than in separate features let me know, we can work out a different review setup.

David and Jaimie - this screen is the only code change for this PR, just the blue box underneath the file upload form. No need to spin up the app to review.